### PR TITLE
Implement draw hitboxes (Cargo feature)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2018"
 [profile.dev.package."*"]
 opt-level = 3
 
+[features]
+default = []
+draw_hitboxes = []
+
 [dependencies]
 nanoserde = "0.1.28"
 macroquad = { version = "0.3" }

--- a/src/nodes/player.rs
+++ b/src/nodes/player.rs
@@ -531,6 +531,24 @@ impl scene::Node for Player {
     }
 
     fn draw(node: RefMut<Self>) {
+        #[cfg(feature = "draw_hitboxes")]
+        {
+            let player_hitbox = Rect::new(
+                node.body.pos.x,
+                node.body.pos.y,
+                PLAYER_HITBOX_WIDTH,
+                PLAYER_HITBOX_HEIGHT,
+            );
+            draw_rectangle_lines(
+                player_hitbox.x,
+                player_hitbox.y,
+                player_hitbox.w,
+                player_hitbox.h,
+                5.,
+                RED,
+            );
+        }
+
         //     let sword_hit_box = if node.fish.facing {
         //         Rect::new(node.pos().x + 35., node.pos().y - 5., 40., 60.)
         //     } else {


### PR DESCRIPTION
Very handy for debugging. Rather than adding commented code, this functionality can cleanly be enabled running like `cargo run --release --features draw_hitboxes`.

In this PR, only the hitbox for the Player is implemented.