### PR TITLE
gamepad-src Make Controller#info readonly

### DIFF
--- a/gamepad-rs/src/platform/windows/mod.rs
+++ b/gamepad-rs/src/platform/windows/mod.rs
@@ -62,7 +62,7 @@ impl ControllerContext {
         }
     }
     /// Get current information of Controller
-    pub fn info(&mut self, index: usize) -> &ControllerInfo {
+    pub fn info(&self, index: usize) -> &ControllerInfo {
         if index < MAX_DEVICES {
             &self.info[index]
         } else {


### PR DESCRIPTION
It's not necessary for this method to be mutable; it breaks the Windows build, and it's readonly on the other O/S configurations.