### PR TITLE
Add spread to machine gun

### DIFF
--- a/src/nodes/bullets.rs
+++ b/src/nodes/bullets.rs
@@ -28,11 +28,12 @@ impl Bullets {
         }
     }
 
-    pub fn spawn_bullet(&mut self, pos: Vec2, size: f32, facing: bool) {
+    pub fn spawn_bullet(&mut self, pos: Vec2, size: f32, facing: bool, spread: f32) {
+        let y = rand::gen_range(-spread, spread);
         let dir = if facing {
-            vec2(1.0, 0.0)
+            vec2(1.0, y)
         } else {
-            vec2(-1.0, 0.0)
+            vec2(-1.0, y)
         };
         self.bullets.push(Bullet {
             pos: pos + vec2(16.0, 30.0) + dir * 32.0,

--- a/src/nodes/machine_gun.rs
+++ b/src/nodes/machine_gun.rs
@@ -52,6 +52,7 @@ pub struct MachineGun {
 
 impl MachineGun {
     pub const GUN_THROWBACK: f32 = 75.0;
+    pub const BULLET_SPREAD: f32 = 0.1;
     pub const FIRE_INTERVAL: f32 = 0.0025; // Time in animation lock between bullets
     pub const MAX_BULLETS: i32 = 20;
 
@@ -192,7 +193,7 @@ impl MachineGun {
                 node.fx_active = true;
 
                 let mut bullets = scene::find_node_by_type::<crate::nodes::Bullets>().unwrap();
-                bullets.spawn_bullet(node.body.pos, 2.0, node.body.facing);
+                bullets.spawn_bullet(node.body.pos, 2.0, node.body.facing, Self::BULLET_SPREAD);
                 player.body.speed.x = -Self::GUN_THROWBACK * player.body.facing_dir();
             }
             {

--- a/src/nodes/muscet.rs
+++ b/src/nodes/muscet.rs
@@ -145,6 +145,7 @@ impl scene::Node for Muscet {
 
 impl Muscet {
     pub const GUN_THROWBACK: f32 = 700.0;
+    pub const BULLET_SPREAD: f32 = 0.0;
 
     pub fn new(facing: bool, pos: Vec2) -> Muscet {
         let muscet_sprite = AnimatedSprite::new(
@@ -276,7 +277,7 @@ impl Muscet {
                 node.muscet_fx = true;
 
                 let mut bullets = scene::find_node_by_type::<crate::nodes::Bullets>().unwrap();
-                bullets.spawn_bullet(node.body.pos, 4.0, node.body.facing);
+                bullets.spawn_bullet(node.body.pos, 4.0, node.body.facing, Self::BULLET_SPREAD);
                 player.body.speed.x = -Self::GUN_THROWBACK * player.body.facing_dir();
             }
             {


### PR DESCRIPTION
This adds a spread parameter to `spawn_bullet` which is used to generate a random value, between `-spread` and `spread` which is, in turn, used as the base of the `y` value of a bullets `speed` (velocity, really).