### PR TITLE
Player 1 keyboard control: Encode fire tapping

### DIFF
--- a/src/nodes/player.rs
+++ b/src/nodes/player.rs
@@ -712,9 +712,12 @@ impl scene::Node for Player {
                 node.input.throw = throw && node.input.was_throw == false;
                 node.input.was_throw = throw;
 
-                node.input.fire = is_key_down(KeyCode::LeftControl)
+                let fire_pressed = is_key_down(KeyCode::LeftControl)
                     || is_key_down(KeyCode::F)
                     || is_key_down(KeyCode::L);
+                node.input.fire = fire_pressed && node.input.was_fire == false;
+                node.input.was_fire = fire_pressed;
+
                 node.input.left = is_key_down(KeyCode::A);
                 node.input.right = is_key_down(KeyCode::D);
                 node.input.down = is_key_down(KeyCode::S);


### PR DESCRIPTION
The tapping logic was not implemented for the fire action, when using the keyboard (1) - it is encoded instead for controllers.

See [related discussion](https://discord.com/channels/865004050357682246/865004050357682251/868629351741136936) for context and thoughts.