### PR TITLE
Fix continuous fire

### DIFF
--- a/src/nodes/player.rs
+++ b/src/nodes/player.rs
@@ -712,11 +712,10 @@ impl scene::Node for Player {
                 node.input.throw = throw && node.input.was_throw == false;
                 node.input.was_throw = throw;
 
-                let fire_pressed = is_key_down(KeyCode::LeftControl)
+                node.input.was_fire = node.input.fire;
+                node.input.fire = is_key_down(KeyCode::LeftControl)
                     || is_key_down(KeyCode::F)
                     || is_key_down(KeyCode::L);
-                node.input.fire = fire_pressed && node.input.was_fire == false;
-                node.input.was_fire = fire_pressed;
 
                 node.input.left = is_key_down(KeyCode::A);
                 node.input.right = is_key_down(KeyCode::D);


### PR DESCRIPTION
This fixes continuous fire, which was disabled in a recent PR.
I kept the `input.was_fire` attribute and in stead updated this to the current state of `input.fire`, before updating this according to player input.

To check if fire input is a result of a hold or a tap, check if `input.fire` is true and that `input.was_fire` is `false`, for tap, or `true`, for hold.