### PR TITLE
Add continous fire for gamepad

### DIFF
--- a/src/nodes/player.rs
+++ b/src/nodes/player.rs
@@ -690,12 +690,8 @@ impl scene::Node for Player {
             }
             node.input.was_jump = state.digital_state[jump_btn];
 
-            if state.digital_state[fire_btn] && node.input.was_fire == false {
-                node.input.fire = true;
-            } else {
-                node.input.fire = false;
-            }
-            node.input.was_fire = state.digital_state[fire_btn];
+            node.input.was_fire = node.input.fire;
+            node.input.fire = state.digital_state[fire_btn];
 
             if state.digital_state[throw_btn] && node.input.was_throw == false {
                 node.input.throw = true;


### PR DESCRIPTION
This just replicates the way continuous fire was fixed for keyboard in a previous PR and applies it to gamepad, as well