### PR TITLE
Fix bullet spawn pos on machine gun

### DIFF
--- a/src/nodes/machine_gun.rs
+++ b/src/nodes/machine_gun.rs
@@ -170,7 +170,8 @@ impl MachineGun {
                 node.fx_active = true;
 
                 let mut bullets = scene::find_node_by_type::<crate::nodes::Bullets>().unwrap();
-                bullets.spawn_bullet(node.body.pos, 2.0, node.body.facing, Self::BULLET_SPREAD);
+                let x = node.body.pos.x + if node.body.facing { 32.0 } else { -32.0 };
+                bullets.spawn_bullet(vec2(x, node.body.pos.y), 2.0, node.body.facing, Self::BULLET_SPREAD);
                 player.body.speed.x = -Self::GUN_THROWBACK * player.body.facing_dir();
             }
             {


### PR DESCRIPTION
This fixes the spawn position of bullets fired from machine gun (used to spawn on player position)