### PR TITLE
Add Circle shape for collision detection

### DIFF
--- a/src/circle.rs
+++ b/src/circle.rs
@@ -1,0 +1,37 @@
+use macroquad::math::{Vec2, Rect, vec2};
+
+
+pub struct Circle {
+    x: f32,
+    y: f32,
+    r: f32,
+}
+
+impl Circle {
+    pub fn new(x: f32, y: f32, r: f32) -> Self {
+        Circle {
+            x,
+            y,
+            r,
+        }
+    }
+
+    pub fn contains(&self, pos: Vec2) -> bool {
+        return pos.distance(vec2(self.x, self.y)) >= self.r;
+    }
+
+    pub fn overlaps(&self, rect: Rect) -> bool {
+        let dist_x = (self.x - rect.x).abs();
+        let dist_y = (self.y - rect.y).abs();
+        if dist_x > rect.w / 2.0 + self.r  || dist_y > rect.h / 2.0 + self.r {
+            return false;
+        }
+        if dist_x <= rect.w / 2.0 || dist_y <= rect.h / 2.0 {
+            return true;
+        }
+        let lhs = dist_x - rect.w / 2.0;
+        let rhs = dist_y - rect.h / 2.0;
+        let dist_sq = (lhs * lhs) + (rhs * rhs);
+        return dist_sq <= self.r * self.r;
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use particles::EmittersCache;
 mod gui;
 mod input_axis;
 mod nodes;
+mod circle;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum GameType {


### PR DESCRIPTION
This adds a module called circle that holds an implementation of a Circle shape.

The type has two methods; `Circle::contains(pos: Vec2)`, which returns a `bool` indicating wheter it contains a point or not, and `Circle::overlaps(rect: Rect)`, which also returns a `bool`, indicating whether there is an overlap between the circle and `rect`.

There should be no need to collision check two circles, as this is intended for use with explosions, so I have not implemented this...