### PR TITLE
Reworked Screen Shake

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod circle;
 mod gui;
 mod input_axis;
 mod nodes;
+mod noise;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum GameType {

--- a/src/nodes/armed_grenade.rs
+++ b/src/nodes/armed_grenade.rs
@@ -142,12 +142,13 @@ impl Node for ArmedGrenade {
                 node.body.pos.y,
                 ArmedGrenade::EXPLOSION_RADIUS,
             );
+            scene::find_node_by_type::<crate::nodes::Camera>()
+                .unwrap()
+                .shake_noise(2., 10, 0.8);
             for mut player in scene::find_nodes_by_type::<crate::nodes::Player>() {
                 if grenade_circ.overlaps_rect(&player.get_hitbox()) {
                     let direction = node.body.pos.x > (player.body.pos.x + 10.);
-                    scene::find_node_by_type::<crate::nodes::Camera>()
-                        .unwrap()
-                        .shake();
+                    
                     player.kill(direction);
                 }
             }

--- a/src/nodes/armed_kick_bomb.rs
+++ b/src/nodes/armed_kick_bomb.rs
@@ -143,12 +143,12 @@ impl Node for ArmedKickBomb {
                 node.body.pos.y,
                 ArmedKickBomb::EXPLOSION_RADIUS,
             );
+            scene::find_node_by_type::<crate::nodes::Camera>()
+                .unwrap()
+                .shake_noise(2., 10, 0.8);
             for mut player in scene::find_nodes_by_type::<crate::nodes::Player>() {
                 if explosion.overlaps_rect(&player.get_hitbox()) {
                     let direction = node.body.pos.x > (player.body.pos.x + 10.);
-                    scene::find_node_by_type::<crate::nodes::Camera>()
-                        .unwrap()
-                        .shake();
                     player.kill(direction);
                 }
             }

--- a/src/nodes/armed_mine.rs
+++ b/src/nodes/armed_mine.rs
@@ -110,10 +110,6 @@ impl scene::Node for ArmedMine {
             for mut player in scene::find_nodes_by_type::<crate::nodes::Player>() {
                 let player_hitbox = player.get_hitbox();
                 if trigger.overlaps_rect(&player_hitbox) {
-                    scene::find_node_by_type::<crate::nodes::Camera>()
-                        .unwrap()
-                        .shake();
-
                     let explosion = Circle::new(
                         node.body.pos.x,
                         node.body.pos.y,
@@ -129,6 +125,9 @@ impl scene::Node for ArmedMine {
             if killed {
                 let mut resources = storage::get_mut::<Resources>();
                 resources.hit_fxses.spawn(node.body.pos);
+                scene::find_node_by_type::<crate::nodes::Camera>()
+                    .unwrap()
+                    .shake_noise(2., 10, 0.8);
                 node.delete();
             }
         }

--- a/src/nodes/bullets.rs
+++ b/src/nodes/bullets.rs
@@ -72,7 +72,7 @@ impl scene::Node for Bullets {
 
                     scene::find_node_by_type::<crate::nodes::Camera>()
                         .unwrap()
-                        .shake();
+                        .shake_noise(0.8, 5, 1.);
 
                     player.kill(direction);
                 }

--- a/src/nodes/cannon.rs
+++ b/src/nodes/cannon.rs
@@ -155,6 +155,10 @@ impl Cannon {
                 );
                 Cannonball::spawn(cannonball_pos, node.body.facing, player.id);
 
+                scene::find_node_by_type::<crate::nodes::Camera>()
+                        .unwrap()
+                        .shake_noise_dir(0.4, 5, 1.0, (1.0, 0.0));
+
                 player.body.speed.x = -CANNON_THROWBACK * player.body.facing_dir();
             }
 

--- a/src/nodes/cannonball.rs
+++ b/src/nodes/cannonball.rs
@@ -157,6 +157,7 @@ impl scene::Node for Cannonball {
                 cannonball.body.pos.y,
                 EXPLOSION_RADIUS,
             );
+            
 
             for mut player in scene::find_nodes_by_type::<crate::nodes::Player>() {
                 if player.id != cannonball.owner_id || cannonball.owner_safe_countdown < 0. {
@@ -164,15 +165,16 @@ impl scene::Node for Cannonball {
                     if explosion.overlaps_rect(&player_hitbox) {
                         hit_fxses.spawn(explosion_position);
 
-                        scene::find_node_by_type::<crate::nodes::Camera>()
-                            .unwrap()
-                            .shake();
+                        
 
                         let direction =
                             cannonball.body.pos.x > (player.body.pos.x + player_hitbox.w / 2.);
                         player.kill(direction);
 
                         cannonball.delete();
+                        scene::find_node_by_type::<crate::nodes::Camera>()
+                            .unwrap()
+                            .shake_noise(1., 6, 0.8);
 
                         return;
                     }
@@ -183,6 +185,9 @@ impl scene::Node for Cannonball {
         }
 
         hit_fxses.spawn(explosion_position);
+        scene::find_node_by_type::<crate::nodes::Camera>()
+            .unwrap()
+            .shake_noise(1., 6, 0.8);
 
         cannonball.delete();
     }

--- a/src/nodes/erupting_volcano.rs
+++ b/src/nodes/erupting_volcano.rs
@@ -96,7 +96,7 @@ impl EruptingVolcano {
         if erupting_volcano.last_shake_time >= SHAKE_INTERVAL {
             scene::find_node_by_type::<crate::nodes::Camera>()
                 .unwrap()
-                .shake();
+                .shake_noise(0.5, 18, 0.5);
             erupting_volcano.last_shake_time = 0.;
         }
     }

--- a/src/nodes/flappy_jellyfish.rs
+++ b/src/nodes/flappy_jellyfish.rs
@@ -219,7 +219,7 @@ impl scene::Node for FlappyJellyfish {
                 if player_hitbox.intersect(flappy_jellyfish_hitbox).is_some() {
                     scene::find_node_by_type::<crate::nodes::Camera>()
                         .unwrap()
-                        .shake();
+                        .shake_noise(0.3, 4, 1.0);
 
                     let direction =
                         flappy_jellyfish.current_pos.x > (player.body.pos.x + player_hitbox.w / 2.);

--- a/src/nodes/flying_curse.rs
+++ b/src/nodes/flying_curse.rs
@@ -164,7 +164,7 @@ impl scene::Node for FlyingCurses {
 
                             scene::find_node_by_type::<crate::nodes::Camera>()
                                 .unwrap()
-                                .shake();
+                                .shake_noise(0.3, 10, 1.0);
 
                             let direction =
                                 flying_curse.current_x > (player.body.pos.x + player_hitbox.w / 2.);

--- a/src/nodes/flying_galleon.rs
+++ b/src/nodes/flying_galleon.rs
@@ -114,7 +114,7 @@ impl scene::Node for FlyingGalleon {
                 if player_hitbox.intersect(flying_galleon_hitbox).is_some() {
                     scene::find_node_by_type::<crate::nodes::Camera>()
                         .unwrap()
-                        .shake();
+                        .shake_noise(0.4, 20, 0.4);
 
                     let direction =
                         flying_galleon.current_pos.x > (player.body.pos.x + player_hitbox.w / 2.);

--- a/src/nodes/machine_gun.rs
+++ b/src/nodes/machine_gun.rs
@@ -182,6 +182,9 @@ impl MachineGun {
                 );
                 player.body.speed.x = -Self::GUN_THROWBACK * player.body.facing_dir();
             }
+            scene::find_node_by_type::<crate::nodes::Camera>()
+                .unwrap()
+                .shake_noise_dir(0.2, 4, 1.4, (1.0, 0.5));
             {
                 let node = &mut *scene::get_node(node);
                 node.sprite.set_animation(1);

--- a/src/nodes/muscet.rs
+++ b/src/nodes/muscet.rs
@@ -269,6 +269,9 @@ impl Muscet {
                 bullets.spawn_bullet(node.body.pos, 4.0, node.body.facing, Self::BULLET_SPREAD);
                 player.body.speed.x = -Self::GUN_THROWBACK * player.body.facing_dir();
             }
+            scene::find_node_by_type::<crate::nodes::Camera>()
+                .unwrap()
+                .shake_noise_dir(0.4, 5, 1.0, (1.0, 0.5));
             {
                 let node = &mut *scene::get_node(node);
                 node.muscet_sprite.set_animation(1);

--- a/src/nodes/player.rs
+++ b/src/nodes/player.rs
@@ -1,3 +1,5 @@
+use std::f32::consts::PI;
+
 use macroquad::{
     audio::{self, play_sound_once},
     color,
@@ -902,7 +904,7 @@ impl scene::Node for Player {
         if is_key_pressed(KeyCode::Q) {
             scene::find_node_by_type::<crate::nodes::Camera>()
                 .unwrap()
-                .shake();
+                .shake_sinusodial(3.0, 20, 2., PI / 2.0);
         }
 
         {

--- a/src/nodes/raining_shark.rs
+++ b/src/nodes/raining_shark.rs
@@ -122,7 +122,7 @@ impl scene::Node for RainingShark {
                 if player_hitbox.intersect(shark_hitbox).is_some() {
                     scene::find_node_by_type::<crate::nodes::Camera>()
                         .unwrap()
-                        .shake();
+                        .shake_noise(0.4, 15, 0.6);
 
                     let direction =
                         shark.current_pos.x > (player.body.pos.x + player_hitbox.w / 2.);

--- a/src/nodes/sword.rs
+++ b/src/nodes/sword.rs
@@ -292,7 +292,7 @@ impl Sword {
                     {
                         scene::find_node_by_type::<crate::nodes::Camera>()
                             .unwrap()
-                            .shake();
+                            .shake_noise(1.5, 3, 0.2);
                         other.kill(!player.body.facing);
                     }
                 }

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,0 +1,106 @@
+// Perlin Stuff
+// Ported from https://github.com/josephg/noisejs/blob/master/perlin.js 
+// This is all magic to me, don't ask me anything about it
+
+
+
+
+pub struct NoiseGenerator{
+	grad_p: [(i32, i32, i32); 512],
+    perm: [usize; 512]
+}
+
+impl NoiseGenerator{
+    const P: [i32; 256] = [151,160,137,91,90,15,
+131,13,201,95,96,53,194,233,7,225,140,36,103,30,69,142,8,99,37,240,21,10,23,
+190, 6,148,247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,57,177,33,
+88,237,149,56,87,174,20,125,136,171,168, 68,175,74,165,71,134,139,48,27,166,
+77,146,158,231,83,111,229,122,60,211,133,230,220,105,92,41,55,46,245,40,244,
+102,143,54, 65,25,63,161, 1,216,80,73,209,76,132,187,208, 89,18,169,200,196,
+135,130,116,188,159,86,164,100,109,198,173,186, 3,64,52,217,226,250,124,123,
+5,202,38,147,118,126,255,82,85,212,207,206,59,227,47,16,58,17,182,189,28,42,
+223,183,170,213,119,248,152, 2,44,154,163, 70,221,153,101,155,167, 43,172,9,
+129,22,39,253, 19,98,108,110,79,113,224,232,178,185, 112,104,218,246,97,228,
+251,34,242,193,238,210,144,12,191,179,162,241, 81,51,145,235,249,14,239,107,
+49,192,214, 31,181,199,106,157,184, 84,204,176,115,121,50,45,127, 4,150,254,
+138,236,205,93,222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180];
+
+    const GRAD_3: [(i32, i32, i32); 12] = 
+    [(1,1,0), (-1,1,0), (1,-1,0), (-1,-1,0),
+     (1,0,1), (-1,0,1), (1,0,-1), (-1,0,-1),
+     (0,1,1), (0,-1,1), (0,1,-1), (0,-1,-1)];
+
+	pub fn new(seed: i32) -> NoiseGenerator{
+        let mut n = NoiseGenerator{
+            grad_p: [(0, 0, 0); 512],
+            perm: [0; 512]
+        };
+        n.seed(seed);
+
+        n
+	}
+
+	pub fn seed(&mut self, seed: i32){
+        let mut seed = seed;
+		if seed > 0 && seed < 1 {
+		// Scale the seed out
+			seed *= 65536;
+		}
+
+		if seed < 256 {
+			seed |= seed << 8;
+		}
+
+        for i in 0..256{
+            let v = if i & 1 > 0{
+                NoiseGenerator::P[i] ^ (seed & 255)
+            }else{
+                NoiseGenerator::P[i] ^ ((seed >> 8) & 255)
+            };
+
+            //self.gradP[i] = 
+            self.perm[i] = v as usize;
+            self.perm[i + 256] = v as usize;
+
+            self.grad_p[i+256] = NoiseGenerator::GRAD_3[(v % 12) as usize];
+            self.grad_p[i] = self.grad_p[i + 256];
+            //noise_generator::gradP[i] = this::gradP[i + 256] = gradv
+
+        }
+	}
+
+    pub fn perlin_2d(&mut self, x: f32, y: f32) -> f32{ // Generates values from -.5 to .5
+        let mut x_f = x.floor() as i32;
+        let mut y_f = y.floor() as i32;
+    
+        let x = x - x_f as f32;
+        let y = y - y_f as f32;
+    
+        x_f = x_f & 255;
+        y_f = y_f & 255;   
+    
+        let n00 = NoiseGenerator::dot2(self.grad_p[x_f as usize     + self.perm[y_f as usize]], x, y);
+        let n01 = NoiseGenerator::dot2(self.grad_p[x_f as usize     + self.perm[(y_f+1) as usize]], x, y-1.0);
+        let n10 = NoiseGenerator::dot2(self.grad_p[(x_f+1) as usize + self.perm[y_f as usize]], x-1.0, y);
+        let n11 = NoiseGenerator::dot2(self.grad_p[(x_f+1) as usize + self.perm[(y_f+1) as usize]], x-1.0, y-1.0);
+
+        let u = NoiseGenerator::fade(x);
+
+        NoiseGenerator::lerp(
+            NoiseGenerator::lerp(n00, n10, u),
+            NoiseGenerator::lerp(n01, n11, u),
+           NoiseGenerator::fade(y))
+    } 
+
+    fn dot2(tuple: (i32, i32, i32), x: f32, y:f32) -> f32{
+        return tuple.0 as f32 * x + tuple.1 as f32 * y;
+    }
+
+    fn fade(t: f32) -> f32 {
+        return t*t*t*(t*(t*6.-15.)+10.);
+    } 
+
+    fn lerp(a: f32, b: f32, t: f32) ->f32{
+        return (1. -t) * a + t*b;
+    }
+}


### PR DESCRIPTION
Reworked screenshake so it looks better and is more flexible. I replaced the rotational shake with translational, which is how it's usually done. (Though a combination could be even better.) There's two shake modes, sinusodial and noise, of which only noise is used at the moment. Sinusodial has a springier feeling, and could work for hard landings or such.

I also added a bunch of shake for different actions, and made it so that explosions always rock the screen. Exact shake values could use some work though.

For the noise, I ported a JS library I have used on a couple other of projects. I have got no idea how it performs, but it works just fine for this. Looking at the output though it seems to sometimes generate short, flat plateaus, but it might also just be that noise looks that way.