### PR TITLE
Add an action for publishing Fish Fight mdbook

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,40 @@
+# From https://github.com/rust-lang/mdBook/pull/1248
+name: Publish Book to gh-pages
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  book:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install mdbook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: "0.3.7"
+
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+
+      - name: Update apt
+        run: sudo apt-get update
+      - name: Install plantuml
+        run: sudo apt-get install plantuml
+
+      - name: Install mdbook-plantuml
+        run: cargo install mdbook-plantuml
+
+      - name: Generate book from markdown
+        run: |
+            cd book
+            mdbook build
+      - name: Publish HTML
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book/book/


### PR DESCRIPTION
#88 This adds a GitHub action for building and deploying the markdown files in `/book` to be served as static website assets on a `gh-pages` branch whenever there's a push to `main` branch. 

To see what the output looks like on the `gh-pages` branch, visit: https://github.com/tigleym/FishFight/tree/gh-pages . The contents of this branch will be overwritten and replaced whenever a build is triggered. 

Since this requires the `gh-pages` branch, someone would need to create it on the main FishFight repo. 



