### PR TITLE
Add android support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "bytecodec"
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -302,20 +302,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
 dependencies = [
  "ahash 0.7.6",
 ]
 
 [[package]]
 name = "hecs"
-version = "0.7.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73385ff16fe24d890e48474bb55748c2c0f0ff5c8f0f19a3a229c7bc96c65a04"
+checksum = "6c0eac587c883895f32067e69a2e241c57b6248eccee80e684033d4e2e1e43c3"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown 0.12.0",
  "spin",
 ]
 
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -813,18 +813,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
  "itoa",
  "ryu",
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -983,9 +983,9 @@ checksum = "fe88247b92c1df6b6de80ddc290f3976dbdf2f5f5d3fd049a9fb598c6dd5ca73"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbow"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37963a389ad05e23d720fc078e4b68bdeec097cc5fd404bb06a6f9a34da82df"
+dependencies = [
+ "crossbundle-derive",
+ "ndk-glue",
+]
+
+[[package]]
+name = "crossbundle-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475f827314bc56db19dcfc0fad7af9795ee7a5d89b5c472e6c9ae8603fd0c8db"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dasp_frame"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +236,7 @@ name = "fishfight"
 version = "0.3.0"
 dependencies = [
  "bincode",
+ "crossbow",
  "ff-particles",
  "fishsticks",
  "hecs",
@@ -200,6 +257,12 @@ dependencies = [
  "cfg-if",
  "sdl2",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fontdue"
@@ -272,6 +335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a164bb2ceaeff4f42542bdb847c41517c78a60f5649671b2a07312b6e117549"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "image"
 version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +360,12 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "lazy_static"
@@ -314,6 +389,15 @@ name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "macroquad"
@@ -392,10 +476,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
+dependencies = [
+ "bitflags",
+ "jni-sys",
+ "ndk-sys 0.3.0",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk-glue"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c0d14b0858eb9962a5dac30b809b19f19da7e4547d64af2b0bb051d2e55d79"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-macro",
+ "ndk-sys 0.3.0",
+]
+
+[[package]]
+name = "ndk-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ndk-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
+
+[[package]]
+name = "ndk-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5a6ae77c8ee183dcbbba6150e2e6b9f3f4196a7666c02a715a95692ec1fa97"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "num-integer"
@@ -439,6 +572,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720d3ea1055e4e4574c0c0b0f8c3fd4f24c4cdaf465948206dea090b57b526ad"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d992b768490d7fe0d8586d9b5745f6c49f557da6d81dc982b1d167ad4edbb21"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ogg"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +624,16 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -570,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c54dc8d8fc38874a0e5cca3a8fba35c7db8e46a3d65f47d0fc999aa48d6a9f"
 dependencies = [
  "libc",
- "ndk-sys",
+ "ndk-sys 0.2.2",
 ]
 
 [[package]]
@@ -700,6 +864,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "stun_codec"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +903,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +127,22 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "core-foundation"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "crc"
@@ -222,6 +244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "ff-particles"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,7 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58c0572ea130de4f1734217e364d885237134ab934c4a6aec35f9b6d9a7613b"
 dependencies = [
  "cfg-if",
- "sdl2",
+ "gilrs",
 ]
 
 [[package]]
@@ -283,6 +311,38 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gilrs"
+version = "0.8.2"
+source = "git+https://github.com/enfipy/gilrs?rev=b5bc88bc173cc2734734aaaf3cfd8cc237e5a0f9#b5bc88bc173cc2734734aaaf3cfd8cc237e5a0f9"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.3.1"
+source = "git+https://github.com/enfipy/gilrs?rev=b5bc88bc173cc2734734aaaf3cfd8cc237e5a0f9#b5bc88bc173cc2734734aaaf3cfd8cc237e5a0f9"
+dependencies = [
+ "core-foundation",
+ "io-kit-sys",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix",
+ "rusty-xinput",
+ "stdweb",
+ "uuid",
+ "vec_map",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -325,7 +385,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1333fad8d94b82cab989da428b0b36a3435db3870d85e971a1d6dc0a8576722"
 dependencies = [
- "sha1",
+ "sha1 0.2.0",
 ]
 
 [[package]]
@@ -356,6 +416,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21dcc74995dd4cd090b147e79789f8d65959cbfb5f0b118002db869ea3bd0a0"
+dependencies = [
+ "core-foundation-sys",
+ "mach",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +436,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -391,12 +470,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "mach"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -531,6 +629,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +716,12 @@ name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "png"
@@ -722,6 +838,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusty-xinput"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2aa654bc32eb9ca14cce1a084abc9dfe43949a4547c35269a094c39272db3bb"
+dependencies = [
+ "lazy_static",
+ "log",
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,27 +925,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sdl2"
-version = "0.35.1"
+name = "semver"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f035f8e87735fa3a8437292be49fe6056450f7cbb13c230b4bcd1bdd7279421f"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "bitflags",
- "lazy_static",
- "libc",
- "sdl2-sys",
+ "semver-parser",
 ]
 
 [[package]]
-name = "sdl2-sys"
-version = "0.35.1"
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb479353c0603785c834e2307440d83d196bf255f204f7f6741358de8d6a2f"
-dependencies = [
- "cfg-if",
- "libc",
- "version-compare",
-]
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -849,6 +977,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 
 [[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
 name = "smallvec"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +1005,57 @@ name = "spin"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1 0.6.1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -976,10 +1170,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "version-compare"
-version = "0.1.0"
+name = "uuid"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88247b92c1df6b6de80ddc290f3976dbdf2f5f5d3fd049a9fb598c6dd5ca73"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -992,6 +1192,70 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 opt-level = 3
 
 [dependencies]
+crossbow = "0.1"
 macroquad = { version = "0.3.10" }
 macroquad-platformer = "0.1"
 macroquad-profiler = "0.1"
@@ -23,3 +24,13 @@ serde_json = "1.0"
 bincode = "1.3.3"
 
 hecs = "0.7.1"
+
+[package.metadata]
+app_name = "Fish Fight"
+target_sdk_version = 30
+version_code = "1"
+icon = "ic_launcher"
+
+android_build_targets = ["aarch64-linux-android"]
+android_assets = "assets"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ hecs = "0.7.1"
 app_name = "Fish Fight"
 target_sdk_version = 30
 version_code = "1"
-icon = "ic_launcher"
 
 android_build_targets = ["aarch64-linux-android"]
 android_assets = "assets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ macroquad-profiler = "0.1"
 
 ff-particles = { version = "0.1", features = ["serde"] }
 
-fishsticks = "0.2.0"
+fishsticks = { version = "0.2.0", default-features = false, features = ["gilrs"] }
 
 stunclient = { git = "https://github.com/not-fl3/rust-stunclient", default-features = false }
 
@@ -24,6 +24,9 @@ serde_json = "1.0"
 bincode = "1.3.3"
 
 hecs = "0.7.1"
+
+[patch.crates-io]
+gilrs = { git = "https://github.com/enfipy/gilrs", rev = "b5bc88bc173cc2734734aaaf3cfd8cc237e5a0f9" }
 
 [package.metadata]
 app_name = "Fish Fight"

--- a/src/editor/input.rs
+++ b/src/editor/input.rs
@@ -97,13 +97,13 @@ pub fn collect_editor_input(scheme: EditorInputScheme) -> EditorInput {
             let gamepad = gamepad_system.gamepad(ix);
 
             if let Some(gamepad) = gamepad {
-                input.action = gamepad.digital_inputs.activated(Button::B);
-                input.back = gamepad.digital_inputs.activated(Button::A);
-                input.context_menu = gamepad.digital_inputs.activated(Button::X);
+                input.action = gamepad.digital_inputs.activated(Button::East);
+                input.back = gamepad.digital_inputs.activated(Button::South);
+                input.context_menu = gamepad.digital_inputs.activated(Button::West);
 
                 input.camera_move_direction = {
-                    let direction_x = gamepad.analog_inputs.value(Axis::LeftX);
-                    let direction_y = gamepad.analog_inputs.value(Axis::LeftY);
+                    let direction_x = gamepad.analog_inputs.value(Axis::LeftStickX);
+                    let direction_y = gamepad.analog_inputs.value(Axis::LeftStickY);
 
                     let direction = vec2(direction_x, direction_y);
 
@@ -111,8 +111,8 @@ pub fn collect_editor_input(scheme: EditorInputScheme) -> EditorInput {
                 };
 
                 input.cursor_move_direction = {
-                    let direction_x = gamepad.analog_inputs.value(Axis::RightX);
-                    let direction_y = gamepad.analog_inputs.value(Axis::RightY);
+                    let direction_x = gamepad.analog_inputs.value(Axis::RightStickX);
+                    let direction_y = gamepad.analog_inputs.value(Axis::RightStickY);
 
                     let direction = vec2(direction_x, direction_y);
 

--- a/src/game/input.rs
+++ b/src/game/input.rs
@@ -72,21 +72,21 @@ pub fn collect_local_input(input_scheme: GameInputScheme) -> GameInput {
             let gamepad = gamepad_context.gamepad(ix);
 
             if let Some(gamepad) = gamepad {
-                input.pickup = gamepad.digital_inputs.just_activated(Button::X);
-                input.fire = gamepad.digital_inputs.activated(Button::B);
+                input.pickup = gamepad.digital_inputs.just_activated(Button::West);
+                input.fire = gamepad.digital_inputs.activated(Button::East);
 
-                input.jump = gamepad.digital_inputs.just_activated(Button::A);
+                input.jump = gamepad.digital_inputs.just_activated(Button::South);
 
                 input.left = gamepad.digital_inputs.activated(Button::DPadLeft)
-                    || gamepad.analog_inputs.digital_value(Axis::LeftX) < 0.0;
+                    || gamepad.analog_inputs.digital_value(Axis::LeftStickX) < 0.0;
 
                 input.right = gamepad.digital_inputs.activated(Button::DPadRight)
-                    || gamepad.analog_inputs.digital_value(Axis::LeftX) > 0.0;
+                    || gamepad.analog_inputs.digital_value(Axis::LeftStickX) > 0.0;
 
                 input.down = gamepad.digital_inputs.activated(Button::DPadDown)
-                    || gamepad.analog_inputs.digital_value(Axis::LeftY) > 0.0;
+                    || gamepad.analog_inputs.digital_value(Axis::LeftStickY) > 0.0;
 
-                input.slide = gamepad.digital_inputs.just_activated(Button::Y)
+                input.slide = gamepad.digital_inputs.just_activated(Button::North)
             }
         }
     }

--- a/src/gui/create_map.rs
+++ b/src/gui/create_map.rs
@@ -125,7 +125,8 @@ pub async fn show_create_map_menu() -> Result<Option<MapResource>> {
                 ui.separator();
                 ui.separator();
 
-                let btn_a = is_gamepad_btn_pressed(Some(&gamepad_system), fishsticks::Button::A);
+                let btn_a =
+                    is_gamepad_btn_pressed(Some(&gamepad_system), fishsticks::Button::South);
                 let enter = is_key_pressed(KeyCode::Enter);
 
                 if ui.button(None, "Confirm") || btn_a || enter {
@@ -151,7 +152,7 @@ pub async fn show_create_map_menu() -> Result<Option<MapResource>> {
 
                 ui.same_line(0.0);
 
-                let btn_b = is_gamepad_btn_pressed(Some(&gamepad_system), fishsticks::Button::B);
+                let btn_b = is_gamepad_btn_pressed(Some(&gamepad_system), fishsticks::Button::East);
                 let escape = is_key_pressed(KeyCode::Escape);
 
                 if ui.button(None, "Cancel") || btn_b || escape {

--- a/src/gui/credits.rs
+++ b/src/gui/credits.rs
@@ -83,7 +83,7 @@ pub async fn show_game_credits(assets_dir: &str) {
 
     loop {
         if is_key_pressed(KeyCode::Escape)
-            || is_gamepad_btn_pressed(Some(&gamepad_context), Button::B)
+            || is_gamepad_btn_pressed(Some(&gamepad_context), Button::East)
         {
             break;
         }

--- a/src/gui/main_menu.rs
+++ b/src/gui/main_menu.rs
@@ -269,7 +269,7 @@ fn local_game_ui(ui: &mut ui::Ui, player_input: &mut Vec<GameInputScheme>) -> Op
     } else {
         let gamepad_context = storage::get::<GamepadContext>();
         if is_key_pressed(KeyCode::Escape)
-            || is_gamepad_btn_pressed(Some(&gamepad_context), Button::B)
+            || is_gamepad_btn_pressed(Some(&gamepad_context), Button::East)
         {
             return Some(Menu::CANCEL_INDEX.into());
         }

--- a/src/gui/menu.rs
+++ b/src/gui/menu.rs
@@ -412,10 +412,10 @@ impl Menu {
             for (_, gamepad) in gamepad_context.gamepads() {
                 gamepad_up = gamepad_up
                     || gamepad.digital_inputs.activated(Button::DPadUp)
-                    || gamepad.analog_inputs.digital_value(Axis::LeftY) < 0.0;
+                    || gamepad.analog_inputs.digital_value(Axis::LeftStickY) < 0.0;
                 gamepad_down = gamepad_down
                     || gamepad.digital_inputs.activated(Button::DPadDown)
-                    || gamepad.analog_inputs.digital_value(Axis::LeftY) > 0.0;
+                    || gamepad.analog_inputs.digital_value(Axis::LeftStickY) > 0.0;
             }
 
             if self.up_grace_timer >= Self::NAVIGATION_GRACE_TIME
@@ -459,10 +459,10 @@ impl Menu {
                 self.current_selection = Some(selection);
             }
 
-            let should_confirm = is_gamepad_btn_pressed(Some(&gamepad_context), Button::A)
+            let should_confirm = is_gamepad_btn_pressed(Some(&gamepad_context), Button::South)
                 || is_key_pressed(KeyCode::Enter);
 
-            let should_cancel = is_gamepad_btn_pressed(Some(&gamepad_context), Button::B)
+            let should_cancel = is_gamepad_btn_pressed(Some(&gamepad_context), Button::East)
                 || is_key_pressed(KeyCode::Escape);
 
             (should_confirm, should_cancel)

--- a/src/gui/select_character.rs
+++ b/src/gui/select_character.rs
@@ -130,14 +130,14 @@ pub async fn show_select_characters_menu(
 
                         if let Some(gamepad) = gamepad {
                             should_navigate_left = can_navigate
-                                && (gamepad.analog_inputs.digital_value(Axis::LeftX) < 0.0
+                                && (gamepad.analog_inputs.digital_value(Axis::LeftStickX) < 0.0
                                     || gamepad.digital_inputs.just_activated(Button::DPadLeft));
 
                             should_navigate_right = can_navigate
-                                && (gamepad.analog_inputs.digital_value(Axis::LeftX) > 0.0
+                                && (gamepad.analog_inputs.digital_value(Axis::LeftStickX) > 0.0
                                     || gamepad.digital_inputs.just_activated(Button::DPadRight));
 
-                            should_confirm = gamepad.digital_inputs.just_activated(Button::A);
+                            should_confirm = gamepad.digital_inputs.just_activated(Button::South);
                         }
                     }
                 }

--- a/src/gui/select_map.rs
+++ b/src/gui/select_map.rs
@@ -48,29 +48,29 @@ pub async fn show_select_map_menu() -> MapResource {
 
             up |= gamepad.digital_inputs.just_activated(Button::DPadUp)
                 || matches!(
-                    gamepad.analog_inputs.just_activated_digital(Axis::LeftY),
+                    gamepad.analog_inputs.just_activated_digital(Axis::LeftStickY),
                     Some(value) if value < 0.0
                 );
 
             down |= gamepad.digital_inputs.just_activated(Button::DPadDown)
                 || matches!(
-                    gamepad.analog_inputs.just_activated_digital(Axis::LeftY),
+                    gamepad.analog_inputs.just_activated_digital(Axis::LeftStickY),
                     Some(value) if value > 0.0
                 );
 
             left |= gamepad.digital_inputs.just_activated(Button::DPadLeft)
                 || matches!(
-                    gamepad.analog_inputs.just_activated_digital(Axis::LeftX),
+                    gamepad.analog_inputs.just_activated_digital(Axis::LeftStickX),
                     Some(value) if value < 0.0
                 );
 
             right |= gamepad.digital_inputs.just_activated(Button::DPadRight)
                 || matches!(
-                    gamepad.analog_inputs.just_activated_digital(Axis::LeftX),
+                    gamepad.analog_inputs.just_activated_digital(Axis::LeftStickX),
                     Some(value) if value > 0.0
                 );
 
-            start |= gamepad.digital_inputs.just_activated(Button::A)
+            start |= gamepad.digital_inputs.just_activated(Button::South)
                 || gamepad.digital_inputs.just_activated(Button::Start);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ async fn main() -> Result<()> {
     use events::iter_events;
     use gui::MainMenuResult;
 
-    let assets_dir = env::var(ASSETS_DIR_ENV_VAR).unwrap_or_else(|_| "./assets".to_string());
+    let assets_dir = env::var(ASSETS_DIR_ENV_VAR).unwrap_or_else(|_| "".to_string());
 
     rand::srand(0);
 


### PR DESCRIPTION
This draft pull request is a quick try to add android support to FishFight. Currently, blocked by the following error:

```sh
01-18 21:12:43.619 10287 10287 I SAPP    : NativeActivity onInputQueueCreated()
01-18 21:12:43.639 10287 10287 I SAPP    : NativeActivity onNativeWindowCreated()
01-18 21:12:43.639 10287 10310 I SAPP    : Creating egl surface
01-18 21:12:43.788 10287 10310 I SAPP    : ... ok!
01-18 21:12:44.110 10287 10287 I SAPP    : NativeActivity onFocusChange()
01-18 21:12:55.938 10287 10310 E SAPP    : PanicInfo { payload: Any { .. }, message: Some(called `Result::unwrap()` on an `Err` value: "Application didn't initialize properly, did you include SDL_main.h in the file containing your main() function?"), location: Location { file: "src/__mainxZRTw7", line: 125, col: 65 } }
```

Also, as a temporary workaround, I changed `assets dir` in main.rs as I couldn't fastly set `ASSETS_DIR_ENV_VAR`.

To reproduce this error - you will need to build `sdl2` ([this](https://julhe.github.io/posts/building-an-android-app-with-rust-and-sdl2/) helped me) from [source](https://www.libsdl.org/download-2.0.php) with this command: `ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./Android.mk APP_PLATFORM=android-18` (if you are on m1 mac - see [this](https://stackoverflow.com/questions/69541831/unknown-host-cpu-architecture-arm64-android-ndk-siliconm1-apple-macbook-pro)), and place `libs/arm64-v8a/libSDL2.so` in your `target/aarch64-linux-android/<PROFILE>/tools/libSDL2.so`. Then install [crossbundle](https://github.com/dodorare/crossbow/tree/main/crossbundle/cli#installation) (or cargo-quad-apk, I think it will work too right now) and run `crossbundle run android --quad`.

Currently, crashing on this stage:
<img width="417" alt="Screenshot 2022-01-18 at 21 36 44" src="https://user-images.githubusercontent.com/24860875/150006501-c2cec169-cea6-416f-bee1-cae9019755c3.png">

@erlend-sh 👋