### PR TITLE
Make System Execution Order More Deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_system_graph"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01982006dc7d468bc38c6362066299bcffeb742066483b131cd1acc3648ecb5f"
+dependencies = [
+ "bevy_ecs",
+ "bevy_utils",
+]
+
+[[package]]
 name = "bevy_tasks"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +2500,7 @@ dependencies = [
  "bevy_ggrs",
  "bevy_kira_audio",
  "bevy_prototype_lyon",
+ "bevy_system_graph",
  "bevy_tweening",
  "bitfield",
  "blocking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bevy_ggrs = { git = "https://github.com/zicklag/bevy_ggrs.git", branch = "jumpy"
 bevy_kira_audio = { version = "0.12.0", features = ["ogg"], default-features = false }
 # bevy_mod_js_scripting = { git = "https://github.com/zicklag/bevy_mod_js_scripting.git", branch = "jumpy" }
 bevy_prototype_lyon = "0.6.0"
+bevy_system_graph = "0.3.0"
 bevy_tweening = { version = "0.5", default-features = false }
 bitfield = "0.14.0"
 blocking = "1.2.0"
@@ -63,13 +64,13 @@ postcard = { git = "https://github.com/zicklag/postcard.git", branch = "custom-e
 rand = "0.8.5"
 rustls = { version = "0.20.7", features = ["dangerous_configuration", "quic"] }
 serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.89"
 serde_yaml = "0.9.2"
 sys-locale = "0.2.1"
 thiserror = "1.0.31"
 tracing = { version = "0.1.37", features = ["release_max_level_debug"] }
 turborand = { version = "0.8.0", features = ["atomic", "serialize"] }
 unic-langid = "0.9.0"
-serde_json = "1.0.89"
 
 [dependencies.bevy]
 version = "0.8"

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -26,34 +26,17 @@ impl Plugin for AnimationPlugin {
                     .register_rollback_type::<AnimationBank>()
                     .register_rollback_type::<AnimationBankSprite>()
             })
-            .extend_rollback_schedule(|schedule| {
-                schedule
-                    .add_stage_after(
-                        RollbackStage::PostUpdate,
-                        AnimationStage::Hydrate,
-                        SystemStage::single_threaded()
-                            .with_system(hydrate_animation_bank_sprites)
-                            .with_system(
-                                hydrate_animated_sprites.after(hydrate_animation_bank_sprites),
-                            ),
-                    )
-                    .add_stage_after(
-                        AnimationStage::Hydrate,
-                        AnimationStage::Animate,
-                        SystemStage::single_threaded()
-                            .with_system(update_animation_bank_sprites)
-                            .with_system(
-                                update_animated_sprite_components
-                                    .after(update_animation_bank_sprites),
-                            )
-                            .with_system(
-                                animate_sprites
-                                    .run_in_state(GameState::InGame)
-                                    .run_not_in_state(InGameState::Paused)
-                                    .after(update_animated_sprite_components.as_system_label()),
-                            ),
-                    );
-            });
+            .add_rollback_system(RollbackStage::PostUpdate, hydrate_animation_bank_sprites)
+            .add_rollback_system(RollbackStage::PostUpdate, hydrate_animated_sprites)
+            .add_rollback_system(RollbackStage::PostUpdate, update_animation_bank_sprites)
+            .add_rollback_system(RollbackStage::PostUpdate, update_animated_sprite_components)
+            .add_rollback_system(
+                RollbackStage::PostUpdate,
+                animate_sprites
+                    .run_in_state(GameState::InGame)
+                    .run_not_in_state(InGameState::Paused)
+                    .after(update_animated_sprite_components.as_system_label()),
+            );
     }
 }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -13,9 +13,7 @@ impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<GameCamera>()
             .register_type::<EditorCamera>()
-            .extend_rollback_schedule(|schedule| {
-                schedule.add_system_to_stage(RollbackStage::Update, camera_controller);
-            });
+            .add_rollback_system(RollbackStage::Update, camera_controller);
 
         app.add_plugin(bevy_parallax::ParallaxPlugin);
     }

--- a/src/damage.rs
+++ b/src/damage.rs
@@ -17,10 +17,7 @@ impl Plugin for DamagePlugin {
                     .register_rollback_type::<DamageRegion>()
                     .register_rollback_type::<DamageRegionOwner>()
             })
-            .extend_rollback_schedule(|schedule| {
-                schedule
-                    .add_system_to_stage(RollbackStage::PostUpdate, kill_players_in_damage_region);
-            });
+            .add_rollback_system(RollbackStage::PostUpdate, kill_players_in_damage_region);
     }
 }
 

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -8,9 +8,7 @@ impl Plugin for LifetimePlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Lifetime>()
             .extend_rollback_plugin(|plugin| plugin.register_rollback_type::<Lifetime>())
-            .extend_rollback_schedule(|schedule| {
-                schedule.add_system_to_stage(RollbackStage::PostUpdate, lifetime_system);
-            });
+            .add_rollback_system(RollbackStage::PostUpdate, lifetime_system);
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -30,12 +30,7 @@ impl Plugin for MapPlugin {
                     .register_rollback_type::<MapElementHydrated>()
                     .register_rollback_type::<Handle<MapElementMeta>>()
             })
-            .extend_rollback_schedule(|schedule| {
-                schedule.add_system_to_stage(
-                    RollbackStage::Last,
-                    handle_out_of_bounds_players_and_items,
-                );
-            })
+            .add_rollback_system(RollbackStage::Last, handle_out_of_bounds_players_and_items)
             .add_plugin(elements::MapElementsPlugin);
     }
 }

--- a/src/map/elements/decoration.rs
+++ b/src/map/elements/decoration.rs
@@ -4,9 +4,7 @@ pub struct DecorationPlugin;
 
 impl Plugin for DecorationPlugin {
     fn build(&self, app: &mut App) {
-        app.extend_rollback_schedule(|schedule| {
-            schedule.add_system_to_stage(RollbackStage::PreUpdate, hydrate_decorations);
-        });
+        app.add_rollback_system(RollbackStage::PreUpdate, hydrate_decorations);
     }
 }
 

--- a/src/map/elements/grenade.rs
+++ b/src/map/elements/grenade.rs
@@ -40,20 +40,14 @@ impl Default for LitGrenade {
 
 impl Plugin for GrenadePlugin {
     fn build(&self, app: &mut App) {
-        app.extend_rollback_schedule(|schedule| {
-            schedule
-                .add_system_to_stage(RollbackStage::PreUpdate, pre_update_in_game)
-                .add_system_to_stage(
-                    RollbackStage::Update,
-                    update_lit_grenades.before(update_idle_grenades),
-                )
-                .add_system_to_stage(RollbackStage::Update, update_idle_grenades);
-        })
-        .extend_rollback_plugin(|plugin| {
-            plugin
-                .register_rollback_type::<IdleGrenade>()
-                .register_rollback_type::<LitGrenade>()
-        });
+        app.add_rollback_system(RollbackStage::PreUpdate, pre_update_in_game)
+            .add_rollback_system(RollbackStage::Update, update_lit_grenades)
+            .add_rollback_system(RollbackStage::Update, update_idle_grenades)
+            .extend_rollback_plugin(|plugin| {
+                plugin
+                    .register_rollback_type::<IdleGrenade>()
+                    .register_rollback_type::<LitGrenade>()
+            });
     }
 }
 

--- a/src/map/elements/player_spawner.rs
+++ b/src/map/elements/player_spawner.rs
@@ -6,9 +6,7 @@ pub struct PlayerSpawnerPlugin;
 impl Plugin for PlayerSpawnerPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CurrentPlayerSpawner>()
-            .extend_rollback_schedule(|schedule| {
-                schedule.add_system_to_stage(RollbackStage::PreUpdate, pre_update_in_game);
-            })
+            .add_rollback_system(RollbackStage::PreUpdate, pre_update_in_game)
             .extend_rollback_plugin(|plugin| {
                 plugin
                     .register_rollback_type::<PlayerSpawner>()

--- a/src/map/elements/sproinger.rs
+++ b/src/map/elements/sproinger.rs
@@ -5,12 +5,9 @@ const FORCE: f32 = 30.0;
 pub struct SproingerPlugin;
 impl Plugin for SproingerPlugin {
     fn build(&self, app: &mut App) {
-        app.extend_rollback_schedule(|schedule| {
-            schedule
-                .add_system_to_stage(RollbackStage::PreUpdate, pre_update_in_game)
-                .add_system_to_stage(RollbackStage::Update, update_in_game);
-        })
-        .extend_rollback_plugin(|plugin| plugin.register_rollback_type::<Sproinger>());
+        app.add_rollback_system(RollbackStage::PreUpdate, pre_update_in_game)
+            .add_rollback_system(RollbackStage::Update, update_in_game)
+            .extend_rollback_plugin(|plugin| plugin.register_rollback_type::<Sproinger>());
     }
 }
 

--- a/src/map/elements/sword.rs
+++ b/src/map/elements/sword.rs
@@ -3,12 +3,9 @@ use super::*;
 pub struct SwordPlugin;
 impl Plugin for SwordPlugin {
     fn build(&self, app: &mut App) {
-        app.extend_rollback_schedule(|schedule| {
-            schedule
-                .add_system_to_stage(RollbackStage::PreUpdate, pre_update_in_game)
-                .add_system_to_stage(RollbackStage::Update, update_in_game);
-        })
-        .extend_rollback_plugin(|plugin| plugin.register_rollback_type::<SwordState>());
+        app.add_rollback_system(RollbackStage::PreUpdate, pre_update_in_game)
+            .add_rollback_system(RollbackStage::Update, update_in_game)
+            .extend_rollback_plugin(|plugin| plugin.register_rollback_type::<SwordState>());
     }
 }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -32,12 +32,10 @@ impl Plugin for PlayerPlugin {
                     .register_rollback_type::<PlayerState>()
                     .register_rollback_type::<PlayerKilled>()
             })
-            .extend_rollback_schedule(|schedule| {
-                schedule.add_system_to_stage(
-                    RollbackStage::PreUpdate,
-                    hydrate_players.run_if_resource_exists::<GameMeta>(),
-                );
-            });
+            .add_rollback_system(
+                RollbackStage::PreUpdate,
+                hydrate_players.run_if_resource_exists::<GameMeta>(),
+            );
     }
 }
 

--- a/src/player/input.rs
+++ b/src/player/input.rs
@@ -24,9 +24,7 @@ impl Plugin for PlayerInputPlugin {
             )
             .add_system_to_stage(CoreStage::Last, clear_input_buffer)
             .extend_rollback_plugin(|plugin| plugin.register_rollback_type::<PlayerInputs>())
-            .extend_rollback_schedule(|schedule| {
-                schedule.add_system_to_stage(RollbackStage::Input, update_user_input);
-            });
+            .add_rollback_system(RollbackStage::Input, update_user_input);
     }
 }
 

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,13 +1,27 @@
 //! Utilities related to system scheduling and, in particular, the netcode rollback schedule.
 
+use bevy::{ecs::schedule::IntoSystemDescriptor, utils::HashMap};
 use bevy_ggrs::GGRSPlugin;
+use bevy_system_graph::{SystemGraph, SystemGraphNode};
 
 use crate::prelude::*;
+
+pub type RollbackSystems = HashMap<RollbackStage, RollbackSystemSet>;
+
+pub struct RollbackSystemSet {
+    pub graph: SystemGraph,
+    pub last_system: SystemGraphNode,
+}
 
 pub trait RollbackScheduleAppExt {
     fn extend_rollback_schedule<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(&mut Schedule);
+    fn add_rollback_system<Params>(
+        &mut self,
+        stage: RollbackStage,
+        system: impl IntoSystemDescriptor<Params>,
+    ) -> &mut Self;
     fn extend_rollback_plugin<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(GGRSPlugin<crate::GgrsConfig>) -> GGRSPlugin<crate::GgrsConfig>;
@@ -22,6 +36,31 @@ impl RollbackScheduleAppExt for App {
         f(&mut schedule);
         self
     }
+
+    fn add_rollback_system<Params>(
+        &mut self,
+        stage: RollbackStage,
+        system: impl IntoSystemDescriptor<Params>,
+    ) -> &mut Self {
+        let mut systems = self.world.non_send_resource_mut::<RollbackSystems>();
+        match systems.get_mut(&stage) {
+            Some(set) => {
+                set.last_system = set.last_system.then(system);
+            }
+            None => {
+                let graph = SystemGraph::new();
+                systems.insert(
+                    stage,
+                    RollbackSystemSet {
+                        last_system: graph.root(system),
+                        graph,
+                    },
+                );
+            }
+        }
+        self
+    }
+
     fn extend_rollback_plugin<F>(&mut self, f: F) -> &mut Self
     where
         F: FnOnce(GGRSPlugin<crate::GgrsConfig>) -> GGRSPlugin<crate::GgrsConfig>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -24,14 +24,9 @@ impl Plugin for SessionPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<FrameIdx>()
             .extend_rollback_plugin(|plugin| plugin.register_rollback_type::<FrameIdx>())
-            .extend_rollback_schedule(|schedule| {
-                schedule.add_system_to_stage(
-                    RollbackStage::Last,
-                    |mut frame_idx: ResMut<FrameIdx>| {
-                        frame_idx.0 = frame_idx.0.wrapping_add(1);
-                        trace!("End of simulation frame {}", frame_idx.0);
-                    },
-                );
+            .add_rollback_system(RollbackStage::Last, |mut frame_idx: ResMut<FrameIdx>| {
+                frame_idx.0 = frame_idx.0.wrapping_add(1);
+                trace!("End of simulation frame {}", frame_idx.0);
             });
     }
 }

--- a/src/utils/event.rs
+++ b/src/utils/event.rs
@@ -9,9 +9,7 @@ pub trait FixedUpdateEventAppExt {
 impl FixedUpdateEventAppExt for bevy::app::App {
     fn add_fixed_update_event<E: Event>(&mut self) -> &mut Self {
         self.init_resource::<Events<E>>()
-            .extend_rollback_schedule(|schedule| {
-                schedule.add_system_to_stage(RollbackStage::First, Events::<E>::update_system);
-            });
+            .add_rollback_system(RollbackStage::First, Events::<E>::update_system);
 
         self
     }


### PR DESCRIPTION
This fixes a network desync issue with grabbing overlapping items.

bors merge