### PR TITLE
fix(docs): Try to Fix Broken Docs Links In CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,11 +45,7 @@ jobs:
 
       - name: Build Rustdoc
         run: |
-          cargo doc -p jumpy --no-deps --document-private-items
-          cargo doc -p jumpy-matchmaker --no-deps --document-private-items
-          cargo doc -p jumpy-matchmaker-proto --no-deps
-          cargo doc -p bevy-has-load-progress --no-deps
-          cargo doc -p quinn-bevy --no-deps
+          cargo doc --workspace --document-private-items --no-deps
           mv target/doc book/src/developers/rustdoc
 
       - name: Build MDBook


### PR DESCRIPTION
Tells cargo to build the docs for the entire workspace. Hopefully that fixes the broken links to other crates in the workspace.

bors merge