### PR TITLE
matchmaker: switch postcard dependency from crate to git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,7 +3448,8 @@ dependencies = [
 [[package]]
 name = "postcard"
 version = "1.0.2"
-source = "git+https://github.com/zicklag/postcard.git?branch=custom-error-messages#b7d417ce3dffa67d8fc3a7128100962701a6b6e2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2b180dc0bade59f03fd005cb967d3f1e5f69b13922dad0cd6e047cb8af2363"
 dependencies = [
  "cobs",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,7 +2532,7 @@ dependencies = [
  "normalize-path",
  "numquant",
  "once_cell",
- "postcard 1.0.2 (git+https://github.com/zicklag/postcard.git?branch=custom-error-messages)",
+ "postcard",
  "quinn",
  "quinn-bevy",
  "rand",
@@ -2564,7 +2564,7 @@ dependencies = [
  "futures-lite",
  "jumpy-matchmaker-proto",
  "once_cell",
- "postcard 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postcard",
  "quinn",
  "quinn-bevy",
  "rand",
@@ -3443,16 +3443,6 @@ dependencies = [
  "log",
  "wepoll-ffi",
  "winapi",
-]
-
-[[package]]
-name = "postcard"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2b180dc0bade59f03fd005cb967d3f1e5f69b13922dad0cd6e047cb8af2363"
-dependencies = [
- "cobs",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ mimalloc = { version = "0.1.32", default-features = false }
 normalize-path = "0.2.0"
 numquant = "0.2.0"
 once_cell = "1.13.0"
-postcard = { git = "https://github.com/zicklag/postcard.git", branch = "custom-error-messages", default-features = false, features = ["alloc", "use-std"] }
+postcard = { version = "1.0.2", default-features = false, features = ["alloc", "use-std"] }
 rand = "0.8.5"
 rustls = { version = "0.20.7", features = ["dangerous_configuration", "quic"] }
 serde = { version = "1.0.137", features = ["derive"] }

--- a/crates/matchmaker/Cargo.toml
+++ b/crates/matchmaker/Cargo.toml
@@ -15,7 +15,7 @@ quinn-bevy = { path = "../quinn-bevy" }
 bevy_tasks = "0.8.1"
 rcgen = "0.10.0"
 rustls = { version = "0.20.7", features = ["dangerous_configuration", "quic"] }
-postcard = { version = "1.0.2", default-features = false, features = ["alloc"] }
+postcard = { git = "https://github.com/zicklag/postcard.git", branch = "custom-error-messages", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.147", features = ["derive"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/crates/matchmaker/Cargo.toml
+++ b/crates/matchmaker/Cargo.toml
@@ -15,7 +15,7 @@ quinn-bevy = { path = "../quinn-bevy" }
 bevy_tasks = "0.8.1"
 rcgen = "0.10.0"
 rustls = { version = "0.20.7", features = ["dangerous_configuration", "quic"] }
-postcard = { git = "https://github.com/zicklag/postcard.git", branch = "custom-error-messages", default-features = false, features = ["alloc"] }
+postcard = { version = "1.0.2", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.147", features = ["derive"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }


### PR DESCRIPTION
otherwise `cargo vendor` fails