### PR TITLE
[Merged by Bors] - feat(ci): Enforce Conventional Commits

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,6 +1,11 @@
+use_squash_merge = true
+cut_body_after = "_ _ _"
+pr_status = [
+# This must be un-commented once Bors merges the PR that new CI check
+#  "Validate conventional PR title",
+]
 status = [
   "Check Rust formatting",
-  "Clippy correctness checks (x86_64-unknown-linux-gnu, target)",
+  "Clippy correctness checks (%)",
   "Build Docs",
-#   "Clippy correctness checks (wasm32-unknown-unknown, web-target)",
 ]

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate conventional PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enforces conventional commits for the repo with a CI job.

This is combined with bors to make it easier for us to merge changes.

_ _ _

This is extra info after the three underscores `_ _ _` that will not be added to the commit message.