### PR TITLE
[Merged by Bors] - fix: make animation end frame index inclusive

### DIFF
--- a/assets/map/elements/item/mine/mine.element.yaml
+++ b/assets/map/elements/item/mine/mine.element.yaml
@@ -12,7 +12,7 @@ builtin: !Mine
 
   arm_sound: ./arm.ogg
   armed_anim_start: 1
-  armed_anim_end: 13
+  armed_anim_end: 12
   armed_anim_fps: 15
 
   damage_region_size: [60, 60]

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -124,7 +124,7 @@ fn animate_sprites(
                 continue;
             }
             animated_sprite.index += 1;
-            animated_sprite.index %= (animated_sprite.end - animated_sprite.start).max(1);
+            animated_sprite.index %= (animated_sprite.end + 1 - animated_sprite.start).max(1);
         }
 
         let sprite_index = animated_sprite.start + animated_sprite.index;


### PR DESCRIPTION
The animation system was looping through the frames, not including the end frame in the animation, which is unintuitive.

This makes the animation system include the final frame.