### PR TITLE
[Merged by Bors] - feat: add camera shake to more items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "bones_camera_shake"
 version = "0.1.0"
-source = "git+https://github.com/DRuppFv/bones?branch=camera_shake_bevy0.8#edfe71fa07340b1bf9a8ea0cf1472b75684d5623"
+source = "git+https://github.com/fishfolk/bones?branch=bevy-0.8#9982c714a4306c5b703a2711e1974a90f296aa69"
 dependencies = [
  "bevy",
  "noise",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ bitfield = "0.14.0"
 blocking = "1.2.0"
 bones_has_load_progress = { git = "https://github.com/fishfolk/bones.git", features = ["bevy_egui"] }
 bones_matchmaker_proto = { git = "https://github.com/fishfolk/bones.git" }
-bones_camera_shake = { git = "https://github.com/DRuppFv/bones", branch = "camera_shake_bevy0.8" }
+bones_camera_shake = { git = "https://github.com/fishfolk/bones", branch = "bevy-0.8" }
 bytemuck = "1.12.3"
 bytes = "1.2.1"
 clap = { version = "4.0.18", features = ["derive", "env"] }

--- a/src/map/elements/kick_bomb.rs
+++ b/src/map/elements/kick_bomb.rs
@@ -1,3 +1,5 @@
+use bones_camera_shake::CameraTrauma;
+
 use std::time::Duration;
 
 use super::*;
@@ -267,6 +269,7 @@ fn update_lit_kick_bombs(
     effects: Res<AudioChannel<EffectsChannel>>,
     mut audio_instances: ResMut<Assets<AudioInstance>>,
     collision_world: CollisionWorld,
+    mut shake_event: EventWriter<CameraTrauma>,
 ) {
     let mut items = kick_bombs.iter_mut().collect::<Vec<_>>();
     items.sort_by_key(|x| x.0.id());
@@ -351,6 +354,8 @@ fn update_lit_kick_bombs(
                     .get_mut(&kick_bomb.fuse_sound)
                     .map(|x| x.stop(AudioTween::linear(Duration::from_secs_f32(0.1))));
             }
+
+            shake_event.send(CameraTrauma(0.75));
 
             commands.entity(item_ent).despawn();
             // Cause the item to re-spawn by re-triggering spawner hydration

--- a/src/map/elements/mine.rs
+++ b/src/map/elements/mine.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is inconsistently named with the rest of the modules ( i.e. has an `_item` suffix )
 //! because `crate` is a Rust keyword.
+use bones_camera_shake::CameraTrauma;
 
 use crate::player::PlayerKillCommand;
 
@@ -256,6 +257,7 @@ fn update_thrown_mines(
     player_inputs: Res<PlayerInputs>,
     effects: Res<AudioChannel<EffectsChannel>>,
     collision_world: CollisionWorld,
+    mut shake_event: EventWriter<CameraTrauma>,
 ) {
     let mut items = mines.iter_mut().collect::<Vec<_>>();
     items.sort_by_key(|x| x.0.id());
@@ -306,6 +308,8 @@ fn update_thrown_mines(
             if player_inputs.is_confirmed {
                 effects.play(explosion_sound_handle.clone_weak());
             }
+
+            shake_event.send(CameraTrauma(0.75));
 
             // Despawn the grenade
             commands.entity(item_ent).despawn();


### PR DESCRIPTION
This adds the camera shake feature to more items.

About the `bones_camera_shake` crate version that uses `bevy 0.8.0`, we should create a new branch in `bones` especially for this version. Just create it and I'll make a pull request.