### PR TITLE
[Merged by Bors] - fix: disable edit button in pause menu.

### DIFF
--- a/src/ui/pause_menu.rs
+++ b/src/ui/pause_menu.rs
@@ -176,6 +176,7 @@ pub fn pause_menu_default(
                         });
 
                         ui.scope(|ui| {
+                            ui.set_enabled(false); // Waiting for editor
                             if BorderedButton::themed(
                                 &ui_theme.button_styles.normal,
                                 &localization.get("edit"),


### PR DESCRIPTION
The editor hasn't been re-implemented yet,
but we do still want to show that we will have support for it later.