### PR TITLE
[Merged by Bors] - fix: prevent musket from buffering fire actions.

### DIFF
--- a/core/src/elements/musket.rs
+++ b/core/src/elements/musket.rs
@@ -155,9 +155,10 @@ fn update(
             // If the item is being used
             let item_used = items_used.get(entity).is_some();
             let can_fire = musket.cooldown_frame >= *cooldown_frames;
-            if item_used && can_fire {
+            if item_used {
                 items_used.remove(entity);
-
+            }
+            if item_used && can_fire {
                 // Empty
                 if musket.ammo.eq(&0) {
                     audio_events.play(empty_shoot_sound.clone(), *empty_shoot_sound_volume);


### PR DESCRIPTION
Previously, if you pressed the fire button quickly more than once,
the musket would fire twice, but slowly, when it should only fire
once.

This makes sure the musket doesn't buffer the fire attempt while it
is still in cooldown frames.