### PR TITLE
[Merged by Bors] - ci: fix web demo build.

### DIFF
--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: jetli/wasm-bindgen-action@v0.1.0
         with:
-          version: "0.2.83"
+          version: "0.2.84"
 
       - name: Build WASM Release 🔨
         run: just build-release-web


### PR DESCRIPTION
The latest cargo update updated wasm-bindgen and broke
the CI job that used the older version of its CLI.

This updates the CI job to match the new wasm-bindgen
version.