### PR TITLE
[Merged by Bors] - chore: add cargo-deny configuration.

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,4 +5,5 @@ status = [
   "🗒 Check Rust formatting",
   "🔧 Clippy correctness checks (%)",
   "🔨 Build Docs",
+  "©️ License and advisories check (bans licenses sources)",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,21 @@ jobs:
         with:
           command: clippy
           args: --target ${{ matrix.config.target }} -- -W clippy::correctness -D warnings
+
+  cargo-deny:
+    name: ©️ License and advisories check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,28 @@
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+unlicensed = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Unlicense",
+    "Zlib",
+    "Apache-2.0 WITH LLVM-exception",
+    "Unicode-DFS-2016",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "MIT-0",
+    "OFL-1.1",
+    "LicenseRef-UFL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "BSD-2-Clause",
+    "MPL-2.0", # TODO(zicklag): I believe MPL is fine for us, but maybe double-check this.
+]
+default = "deny"
+
+[sources.allow-org]
+github = [
+    "fishfolk",
+]


### PR DESCRIPTION
This will help us make sure we only include projects with licenses
suitable for commercial development.