### PR TITLE
[Merged by Bors] - fix: fix Level 4 freezing when loading.

### DIFF
--- a/assets/map/levels/level4.map.yaml
+++ b/assets/map/levels/level4.map.yaml
@@ -1212,7 +1212,7 @@ layers:
             - 130
           element: /elements/item/stomp_boots/stomp_boots.element.yaml
         - pos:
-            - 76
+            - 83
             - 130
           element: /elements/item/stomp_boots/stomp_boots.element.yaml
         - pos:


### PR DESCRIPTION
The issue is that stomp boots were spawning in the wall
which made physics engine go crazy. 

Closes: https://github.com/fishfolk/jumpy/issues/623
_ _ _
In future some collision check should be added probably and if item is configured to spawn in the wall we could log some error and throw exception or something to be more explicit about what is wrong.