### PR TITLE
[Merged by Bors] - fix: increase killing velocity so that sword does not kill player when dropped in place

### DIFF
--- a/assets/elements/item/sword/sword.element.yaml
+++ b/assets/elements/item/sword/sword.element.yaml
@@ -8,9 +8,9 @@ builtin: !Sword
   grab_offset: [18, 26]
   body_size: [50, 8]
   # The minimum speed the sword must be moving to kill somebody
-  killing_speed: 7
+  killing_speed: 7.0
   angular_velocity: -0.04
   can_rotate: true
   bounciness: 0.32
-  throw_velocity: [1, 4]
+  throw_velocity: [1.5, 6]
   cooldown_frames: 22

--- a/core/src/elements/sword.rs
+++ b/core/src/elements/sword.rs
@@ -314,7 +314,7 @@ fn update(
 
             let transform = transforms.get_mut(entity).unwrap();
             transform.translation =
-                player_translation + (*grab_offset * horizontal_flip_factor).extend(0.0);
+                player_translation + (vec2(grab_offset.x, 0.0) *  horizontal_flip_factor).extend(0.0);
         }
     }
 }

--- a/core/src/elements/sword.rs
+++ b/core/src/elements/sword.rs
@@ -313,8 +313,8 @@ fn update(
             body.is_spawning = true;
 
             let transform = transforms.get_mut(entity).unwrap();
-            transform.translation =
-                player_translation + (vec2(grab_offset.x, 0.0) *  horizontal_flip_factor).extend(0.0);
+            transform.translation = player_translation
+                + (vec2(grab_offset.x, 0.0) * horizontal_flip_factor).extend(0.0);
         }
     }
 }


### PR DESCRIPTION
Tweaks sword drop position and throw velocity which
prevents you from killing yourself when dropping the
sword.

fixes: #635
_ _ _
I tested some sensible scenarios and it seems that throwing sword still kills enemy as expected. Value can be adjusted further down the road.