### PR TITLE
[Merged by Bors] - feat: use different death animations depending on hit direction.

### DIFF
--- a/assets/player/skins/fishy/fishy.player.yaml
+++ b/assets/player/skins/fishy/fishy.player.yaml
@@ -92,7 +92,7 @@ layers:
             offset: [0, -4]
         fps: *fps
         repeat: false
-      death_1:
+      death_spine:
         frames:
           - idx: 70
           - idx: 71
@@ -101,6 +101,17 @@ layers:
           - idx: 74
           - idx: 75
           - idx: 76
+        fps: *fps
+        repeat: false
+      death_belly:
+        frames:
+          - idx: 84
+          - idx: 85
+          - idx: 86
+          - idx: 87
+          - idx: 88
+          - idx: 89
+          - idx: 90
         fps: *fps
         repeat: false
   fin:
@@ -144,7 +155,11 @@ layers:
         fps: *fps
         frames:
           - 20
-      death_1:
+      death_spine:
+        fps: *fps
+        frames:
+          - 3 # Intentionally an invisible frame
+      death_belly:
         fps: *fps
         frames:
           - 3 # Intentionally an invisible frame
@@ -192,7 +207,11 @@ layers:
         fps: *fps
         frames:
           - 5
-      death_1:
+      death_spine:
+        fps: *fps
+        frames:
+          - 10 # Intentionally an invisible frame
+      death_belly:
         fps: *fps
         frames:
           - 10 # Intentionally an invisible frame

--- a/assets/player/skins/orcy/orcy.player.yaml
+++ b/assets/player/skins/orcy/orcy.player.yaml
@@ -92,7 +92,7 @@ layers:
             offset: [0, -4]
         fps: *fps
         repeat: false
-      death_1:
+      death_spine:
         frames:
           - idx: 70
           - idx: 71
@@ -101,6 +101,17 @@ layers:
           - idx: 74
           - idx: 75
           - idx: 76
+        fps: *fps
+        repeat: false
+      death_belly:
+        frames:
+          - idx: 84
+          - idx: 85
+          - idx: 86
+          - idx: 87
+          - idx: 88
+          - idx: 89
+          - idx: 90
         fps: *fps
         repeat: false
   fin:
@@ -144,7 +155,11 @@ layers:
         fps: *fps
         frames:
           - 20
-      death_1:
+      death_spine:
+        fps: *fps
+        frames:
+          - 3 # Intentionally an invisible frame
+      death_belly:
         fps: *fps
         frames:
           - 3 # Intentionally an invisible frame
@@ -194,7 +209,11 @@ layers:
         fps: *fps
         frames:
           - 4
-      death_1:
+      death_spine:
+        fps: *fps
+        frames:
+          - 8 # Intentionally an invisible frame
+      death_belly:
         fps: *fps
         frames:
           - 8 # Intentionally an invisible frame

--- a/assets/player/skins/pescy/pescy.player.yaml
+++ b/assets/player/skins/pescy/pescy.player.yaml
@@ -92,7 +92,7 @@ layers:
             offset: [0, -4]
         fps: *fps
         repeat: false
-      death_1:
+      death_spine:
         frames:
           - idx: 70
           - idx: 71
@@ -101,6 +101,17 @@ layers:
           - idx: 74
           - idx: 75
           - idx: 76
+        fps: *fps
+        repeat: false
+      death_belly:
+        frames:
+          - idx: 84
+          - idx: 85
+          - idx: 86
+          - idx: 87
+          - idx: 88
+          - idx: 89
+          - idx: 90
         fps: *fps
         repeat: false
   fin:
@@ -144,7 +155,11 @@ layers:
         fps: *fps
         frames:
           - 20
-      death_1:
+      death_spine:
+        fps: *fps
+        frames:
+          - 3 # Intentionally an invisible frame
+      death_belly:
         fps: *fps
         frames:
           - 3 # Intentionally an invisible frame
@@ -194,7 +209,11 @@ layers:
         fps: *fps
         frames:
           - 4
-      death_1:
+      death_spine:
+        fps: *fps
+        frames:
+          - 8 # Intentionally an invisible frame
+      death_belly:
         fps: *fps
         frames:
           - 8 # Intentionally an invisible frame

--- a/assets/player/skins/sharky/sharky.player.yaml
+++ b/assets/player/skins/sharky/sharky.player.yaml
@@ -92,7 +92,7 @@ layers:
             offset: [0, -4]
         fps: *fps
         repeat: false
-      death_1:
+      death_spine:
         frames:
           - idx: 70
           - idx: 71
@@ -101,6 +101,17 @@ layers:
           - idx: 74
           - idx: 75
           - idx: 76
+        fps: *fps
+        repeat: false
+      death_belly:
+        frames:
+          - idx: 84
+          - idx: 85
+          - idx: 86
+          - idx: 87
+          - idx: 88
+          - idx: 89
+          - idx: 90
         fps: *fps
         repeat: false
   fin:
@@ -144,7 +155,11 @@ layers:
         fps: *fps
         frames:
           - 20
-      death_1:
+      death_spine:
+        fps: *fps
+        frames:
+          - 3 # Intentionally an invisible frame
+      death_belly:
         fps: *fps
         frames:
           - 3 # Intentionally an invisible frame
@@ -194,7 +209,11 @@ layers:
         fps: *fps
         frames:
           - 4
-      death_1:
+      death_spine:
+        fps: *fps
+        frames:
+          - 8 # Intentionally an invisible frame
+      death_belly:
         fps: *fps
         frames:
           - 8 # Intentionally an invisible frame

--- a/core/src/bullet.rs
+++ b/core/src/bullet.rs
@@ -121,7 +121,7 @@ fn update(
             .filter(|&x| player_indexes.contains(x))
             .for_each(|player| {
                 hit_player = true;
-                player_events.kill(player);
+                player_events.kill(player, Some(position.translation.xy()));
             });
 
         // check solid tile collisions

--- a/core/src/damage.rs
+++ b/core/src/damage.rs
@@ -59,7 +59,7 @@ fn kill_players_in_damage_region(
 
             let damage_rect = damage_region.collider_rect(transform.translation);
             if player_rect.overlaps(&damage_rect) {
-                player_events.kill(player_ent);
+                player_events.kill(player_ent, Some(transform.translation.xy()));
             }
         }
     }

--- a/core/src/elements/crate_item.rs
+++ b/core/src/elements/crate_item.rs
@@ -300,7 +300,7 @@ fn update_thrown_crates(
             .collect::<Vec<_>>();
 
         for player_entity in &colliding_with_players {
-            player_events.kill(*player_entity);
+            player_events.kill(*player_entity, Some(transform.translation.xy()));
         }
 
         if !colliding_with_players.is_empty()

--- a/core/src/elements/mine.rs
+++ b/core/src/elements/mine.rs
@@ -227,6 +227,7 @@ fn update_thrown_mines(
     mut player_events: ResMut<PlayerEvents>,
     mut commands: Commands,
     collision_world: CollisionWorld,
+    transforms: Comp<Transform>,
 ) {
     let players = entities
         .iter_with(&player_indexes)
@@ -271,8 +272,10 @@ fn update_thrown_mines(
             .collect::<Vec<_>>();
 
         if !colliding_with_players.is_empty() && thrown_mine.age >= *arm_delay {
+            let mine_transform = *transforms.get(entity).unwrap();
+
             for player in &colliding_with_players {
-                player_events.kill(*player);
+                player_events.kill(*player, Some(mine_transform.translation.xy()));
             }
 
             audio_events.play(explosion_sound.clone(), *explosion_volume);
@@ -293,7 +296,7 @@ fn update_thrown_mines(
                       mut lifetimes: CompMut<Lifetime>,
                       mut sprites: CompMut<AtlasSprite>,
                       mut animated_sprites: CompMut<AnimatedSprite>| {
-                    let explosion_transform = *transforms.get(entity).unwrap();
+                    let explosion_transform = mine_transform;
 
                     // Despawn the grenade
                     entities.kill(entity);

--- a/core/src/elements/stomp_boots.rs
+++ b/core/src/elements/stomp_boots.rs
@@ -228,7 +228,7 @@ fn update_wearer(
                         .center()
                         .y
                 {
-                    player_events.kill(player)
+                    player_events.kill(player, Some(player_transform.translation.xy()))
                 }
             });
     }

--- a/core/src/elements/sword.rs
+++ b/core/src/elements/sword.rs
@@ -268,6 +268,8 @@ fn update(
             sword.dropped_time += 1.0 / crate::FPS;
 
             if body.velocity.length() >= *killing_speed {
+                let sword_transform = transforms.get(entity).unwrap();
+
                 collision_world
                     .actor_collisions(entity)
                     .into_iter()
@@ -277,7 +279,9 @@ fn update(
                             (player_body.velocity - body.velocity).length() >= *killing_speed
                         }
                     })
-                    .for_each(|player| player_events.kill(player));
+                    .for_each(|player| {
+                        player_events.kill(player, Some(sword_transform.translation.xy()))
+                    });
             }
         }
 

--- a/core/src/map.rs
+++ b/core/src/map.rs
@@ -169,7 +169,7 @@ fn handle_out_of_bounds_players_and_items(
         let pos = transform.translation;
 
         if pos.x < left_kill_zone || pos.x > right_kill_zone || pos.y < bottom_kill_zone {
-            player_events.kill(player_ent);
+            player_events.kill(player_ent, None);
         }
     }
 

--- a/core/src/player/state/states/dead.rs
+++ b/core/src/player/state/states/dead.rs
@@ -15,16 +15,35 @@ pub fn player_state_transition(
 pub fn handle_player_state(
     entities: Res<Entities>,
     player_states: Comp<PlayerState>,
+    killed_players: Comp<PlayerKilled>,
+    sprites: Comp<AtlasSprite>,
+    transform: Comp<Transform>,
     mut animations: CompMut<AnimationBankSprite>,
     mut player_events: ResMut<PlayerEvents>,
 ) {
-    for (player_ent, (state, animation)) in entities.iter_with((&player_states, &mut animations)) {
+    for (player_ent, (state, animation, killed_player)) in
+        entities.iter_with((&player_states, &mut animations, &killed_players))
+    {
         if state.current != ID {
             continue;
         };
 
         if state.age == 0 {
-            animation.current = key!("death_1");
+            let sprite = sprites.get(player_ent).unwrap();
+            let player_on_right = !sprite.flip_x;
+            let transform = transform.get(player_ent).unwrap();
+
+            animation.current = match killed_player.hit_from {
+                Some(hit_from)
+                    if {
+                        let is_hit_right = transform.translation.x < hit_from.x;
+                        (player_on_right && is_hit_right) || (!player_on_right && !is_hit_right)
+                    } =>
+                {
+                    key!("death_spine")
+                }
+                _ => key!("death_belly"),
+            };
         }
 
         if state.age >= 80 {


### PR DESCRIPTION
Reimplementing feature from old jumpy implementation.
_ _ _
![deaths](https://user-images.githubusercontent.com/40376451/220704830-fcbf4a7c-4177-477b-8356-19f599e0f3c8.gif)