### PR TITLE
[Merged by Bors] - feat: add new item throw behaviors.

### DIFF
--- a/assets/elements/item/crate/crate.element.yaml
+++ b/assets/elements/item/crate/crate.element.yaml
@@ -1,7 +1,7 @@
 name: Crate
 category: Weapons
 builtin: !Crate
-  throw_velocity: [7, 5]
+  throw_velocity: 10
 
   atlas: ./crate.atlas.yaml
 

--- a/assets/elements/item/grenade/grenade.element.yaml
+++ b/assets/elements/item/grenade/grenade.element.yaml
@@ -4,7 +4,7 @@ editor:
   grab_size: [30, 30]
 builtin: !Grenade
   fuse_time: 4.0
-  throw_velocity: [7, 6]
+  throw_velocity: 12
   damage_region_size: [60, 60]
   damage_region_lifetime: 0.6
 

--- a/assets/elements/item/kick_bomb/kick_bomb.element.yaml
+++ b/assets/elements/item/kick_bomb/kick_bomb.element.yaml
@@ -2,7 +2,8 @@ name: Kick Bomb
 category: Weapons
 builtin: !KickBomb
   fuse_time: 8.0
-  throw_velocity: [10, 6]
+  kick_velocity: [10, 6]
+  throw_velocity: 10
   damage_region_size: [60, 60]
   damage_region_lifetime: 0.6
 

--- a/assets/elements/item/mine/mine.element.yaml
+++ b/assets/elements/item/mine/mine.element.yaml
@@ -4,7 +4,7 @@ builtin: !Mine
   damage_region_size: [60, 60]
   damage_region_lifetime: 0.6
   arm_delay: 0.5
-  throw_velocity: [7, 5]
+  throw_velocity: 9
 
   atlas: ./mine.atlas.yaml
 

--- a/assets/elements/item/musket/musket.element.yaml
+++ b/assets/elements/item/musket/musket.element.yaml
@@ -21,5 +21,5 @@ builtin: !Musket
   body_size: [32, 8]
   fin_anim: grab_2
   angular_velocity: 0.1
-  throw_velocity: [7, 6]
+  throw_velocity: 6
   grab_offset: [23  , 0]

--- a/assets/elements/item/sword/sword.element.yaml
+++ b/assets/elements/item/sword/sword.element.yaml
@@ -14,5 +14,5 @@ builtin: !Sword
   angular_velocity: -0.04
   can_rotate: true
   bounciness: 0.32
-  throw_velocity: [1.5, 6]
+  throw_velocity: 9
   cooldown_frames: 22

--- a/core/src/bullet.rs
+++ b/core/src/bullet.rs
@@ -84,7 +84,6 @@ fn update(
 
     player_indexes: Comp<PlayerIdx>,
     collision_world: CollisionWorld,
-    mut player_events: ResMut<PlayerEvents>,
     mut transforms: CompMut<Transform>,
     mut bullets: CompMut<Bullet>,
     mut audio_events: ResMut<AudioEvents>,
@@ -121,7 +120,7 @@ fn update(
             .filter(|&x| player_indexes.contains(x))
             .for_each(|player| {
                 hit_player = true;
-                player_events.kill(player, Some(position.translation.xy()));
+                commands.add(PlayerEvent::kill(player, Some(position.translation.xy())));
             });
 
         // check solid tile collisions

--- a/core/src/bullet.rs
+++ b/core/src/bullet.rs
@@ -120,7 +120,7 @@ fn update(
             .filter(|&x| player_indexes.contains(x))
             .for_each(|player| {
                 hit_player = true;
-                commands.add(PlayerEvent::kill(player, Some(position.translation.xy())));
+                commands.add(PlayerCommand::kill(player, Some(position.translation.xy())));
             });
 
         // check solid tile collisions

--- a/core/src/damage.rs
+++ b/core/src/damage.rs
@@ -36,12 +36,12 @@ pub struct DamageRegionOwner(pub Entity);
 /// System that will eliminate players that are intersecting with a damage region.
 fn kill_players_in_damage_region(
     entities: Res<Entities>,
+    mut commands: Commands,
     player_indexes: Comp<PlayerIdx>,
     transforms: Comp<Transform>,
     damage_regions: Comp<DamageRegion>,
     damage_region_owners: Comp<DamageRegionOwner>,
     bodies: Comp<KinematicBody>,
-    mut player_events: ResMut<PlayerEvents>,
 ) {
     for (player_ent, (_idx, transform, body)) in
         entities.iter_with((&player_indexes, &transforms, &bodies))
@@ -59,7 +59,10 @@ fn kill_players_in_damage_region(
 
             let damage_rect = damage_region.collider_rect(transform.translation);
             if player_rect.overlaps(&damage_rect) {
-                player_events.kill(player_ent, Some(transform.translation.xy()));
+                commands.add(PlayerEvent::kill(
+                    player_ent,
+                    Some(transform.translation.xy()),
+                ));
             }
         }
     }

--- a/core/src/damage.rs
+++ b/core/src/damage.rs
@@ -59,7 +59,7 @@ fn kill_players_in_damage_region(
 
             let damage_rect = damage_region.collider_rect(transform.translation);
             if player_rect.overlaps(&damage_rect) {
-                commands.add(PlayerEvent::kill(
+                commands.add(PlayerCommand::kill(
                     player_ent,
                     Some(transform.translation.xy()),
                 ));

--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -34,9 +34,6 @@ pub struct ElementHandle(pub Handle<ElementMeta>);
 pub fn install(session: &mut GameSession) {
     session
         .stages
-        .add_system_to_stage(CoreStage::Last, throw_dropped_items);
-    session
-        .stages
         .add_system_to_stage(CoreStage::First, handle_out_of_bounds_items);
 
     decoration::install(session);
@@ -66,119 +63,6 @@ fn handle_out_of_bounds_items(
             commands.add(move |mut entities: ResMut<Entities>| {
                 entities.kill(item_ent);
             });
-        }
-    }
-}
-
-/// Component defining the strength of the throw types when an item is dropped.
-///
-/// Mainly handled by the [`throw_dropped_items`] system.
-#[derive(Clone, Copy, TypeUlid)]
-#[ulid = "01GSGE6N4TSEMQ1DKDP5Y66TE4"]
-pub struct ItemThrow {
-    normal: Vec2,
-    fast: Vec2,
-    up: Vec2,
-    drop: Vec2,
-    lob: Vec2,
-    roll: Vec2,
-    spin: f32,
-}
-
-impl ItemThrow {
-    /// Generally what to start with for throw velocities. The standard `spin` is `0.0`.
-    fn standard() -> Self {
-        Self {
-            normal: Vec2::new(1.5, 1.2).normalize() * 0.6,
-            fast: Vec2::new(1.5, 1.2).normalize(),
-            up: Vec2::new(0.0, 1.1),
-            drop: Vec2::new(0.0, 0.0),
-            lob: Vec2::new(1.0, 2.5).normalize() * 1.1,
-            roll: Vec2::new(0.4, -0.1),
-            spin: 0.0,
-        }
-    }
-    /// `Self::standard` with the throw values multiplied by `strength`.
-    fn strength(strength: f32) -> Self {
-        Self {
-            normal: Self::standard().normal * strength,
-            fast: Self::standard().fast * strength,
-            up: Self::standard().up * strength,
-            drop: Self::standard().drop * strength,
-            lob: Self::standard().lob * strength,
-            roll: Self::standard().roll * strength,
-            spin: 0.0,
-        }
-    }
-    fn with_spin(self, spin: f32) -> Self {
-        Self { spin, ..self }
-    }
-    /// Chooses one of the throw values based on a [`PlayerControl`]
-    fn velocity_from_control(&self, player_control: &PlayerControl) -> Vec2 {
-        let PlayerControl { move_direction, .. } = player_control;
-        let y = move_direction.y;
-        let moving = move_direction.x.abs() > 0.0;
-        if y < 0.0 {
-            if moving {
-                return self.roll;
-            } else {
-                return self.drop;
-            }
-        }
-        if moving {
-            if y > 0.0 {
-                self.lob
-            } else {
-                self.fast
-            }
-        } else if y > 0.0 {
-            self.up
-        } else {
-            self.normal
-        }
-    }
-}
-
-fn throw_dropped_items(
-    entities: Res<Entities>,
-    item_throws: Comp<ItemThrow>,
-    items: Comp<Item>,
-    player_inputs: Res<PlayerInputs>,
-    player_indexes: Comp<PlayerIdx>,
-    mut items_dropped: CompMut<ItemDropped>,
-    mut bodies: CompMut<KinematicBody>,
-    mut attachments: CompMut<PlayerBodyAttachment>,
-    mut sprites: CompMut<AtlasSprite>,
-    mut commands: Commands,
-) {
-    for (entity, (_items, item_throw, body)) in
-        entities.iter_with((&items, &item_throws, &mut bodies))
-    {
-        if let Some(ItemDropped { player }) = items_dropped.remove(entity) {
-            commands.add(PlayerCommand::set_inventory(player, None));
-            attachments.remove(entity);
-
-            let player_sprite = sprites.get_mut(player).unwrap();
-
-            let horizontal_flip_factor = if player_sprite.flip_x {
-                Vec2::new(-1.0, 1.0)
-            } else {
-                Vec2::ONE
-            };
-
-            let throw_velocity = item_throw.velocity_from_control(
-                &player_inputs
-                    .players
-                    .get(player_indexes.get(player).unwrap().0)
-                    .unwrap()
-                    .control,
-            );
-
-            body.velocity = throw_velocity * horizontal_flip_factor;
-            body.angular_velocity =
-                item_throw.spin * horizontal_flip_factor.x * throw_velocity.y.signum();
-
-            body.is_deactivated = false;
         }
     }
 }

--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -34,6 +34,9 @@ pub struct ElementHandle(pub Handle<ElementMeta>);
 pub fn install(session: &mut GameSession) {
     session
         .stages
+        .add_system_to_stage(CoreStage::Last, throw_dropped_items);
+    session
+        .stages
         .add_system_to_stage(CoreStage::First, handle_out_of_bounds_items);
 
     decoration::install(session);
@@ -63,6 +66,111 @@ fn handle_out_of_bounds_items(
             commands.add(move |mut entities: ResMut<Entities>| {
                 entities.kill(item_ent);
             });
+        }
+    }
+}
+
+/// Component defining the strength of the throw types when an item is dropped.
+///
+/// Mainly handled by the [`throw_dropped_items`] system.
+#[derive(Clone, Copy, TypeUlid)]
+#[ulid = "01GSGE6N4TSEMQ1DKDP5Y66TE4"]
+pub struct ItemThrow {
+    normal: Vec2,
+    fast: Vec2,
+    up: Vec2,
+    drop: Vec2,
+    lob: Vec2,
+    spin: f32,
+}
+
+impl ItemThrow {
+    /// Generally what to start with for throw velocities. The standard `spin` is `0.0`.
+    fn standard() -> Self {
+        Self {
+            normal: Vec2::new(1.5, 1.2).normalize() * 0.6,
+            fast: Vec2::new(1.5, 1.2).normalize(),
+            up: Vec2::new(0.0, 1.1),
+            drop: Vec2::new(0.0, 0.0),
+            lob: Vec2::new(1.0, 2.5).normalize() * 1.1,
+            spin: 0.0,
+        }
+    }
+    /// `Self::standard` with the throw values multiplied by `strength`.
+    fn strength(strength: f32) -> Self {
+        Self {
+            normal: Self::standard().normal * strength,
+            fast: Self::standard().fast * strength,
+            up: Self::standard().up * strength,
+            drop: Self::standard().drop * strength,
+            lob: Self::standard().lob * strength,
+            spin: 0.0,
+        }
+    }
+    fn with_spin(self, spin: f32) -> Self {
+        Self { spin, ..self }
+    }
+    /// Chooses one of the throw values based on a [`PlayerControl`]
+    fn velocity_from_control(&self, player_control: &PlayerControl) -> Vec2 {
+        let PlayerControl { move_direction, .. } = player_control;
+        let y = move_direction.y;
+        let moving = move_direction.x.abs() > 0.0;
+        if y < 0.0 {
+            return self.drop;
+        }
+        if moving {
+            if y > 0.0 {
+                self.lob
+            } else {
+                self.fast
+            }
+        } else if y > 0.0 {
+            self.up
+        } else {
+            self.normal
+        }
+    }
+}
+
+fn throw_dropped_items(
+    entities: Res<Entities>,
+    item_throws: Comp<ItemThrow>,
+    items: Comp<Item>,
+    player_inputs: Res<PlayerInputs>,
+    player_indexes: Comp<PlayerIdx>,
+    mut items_dropped: CompMut<ItemDropped>,
+    mut bodies: CompMut<KinematicBody>,
+    mut attachments: CompMut<PlayerBodyAttachment>,
+    mut sprites: CompMut<AtlasSprite>,
+    mut commands: Commands,
+) {
+    for (entity, (_items, item_throw, body)) in
+        entities.iter_with((&items, &item_throws, &mut bodies))
+    {
+        if let Some(ItemDropped { player }) = items_dropped.remove(entity) {
+            commands.add(PlayerEvent::set_inventory(player, None));
+            attachments.remove(entity);
+
+            let player_sprite = sprites.get_mut(player).unwrap();
+
+            let horizontal_flip_factor = if player_sprite.flip_x {
+                Vec2::new(-1.0, 1.0)
+            } else {
+                Vec2::ONE
+            };
+
+            let throw_velocity = item_throw.velocity_from_control(
+                &player_inputs
+                    .players
+                    .get(player_indexes.get(player).unwrap().0)
+                    .unwrap()
+                    .control,
+            );
+
+            body.velocity = throw_velocity * horizontal_flip_factor;
+            body.angular_velocity = item_throw.spin * if player_sprite.flip_x { -1.0 } else { 1.0 };
+
+            body.is_deactivated = false;
         }
     }
 }

--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -81,6 +81,7 @@ pub struct ItemThrow {
     up: Vec2,
     drop: Vec2,
     lob: Vec2,
+    roll: Vec2,
     spin: f32,
 }
 
@@ -93,6 +94,7 @@ impl ItemThrow {
             up: Vec2::new(0.0, 1.1),
             drop: Vec2::new(0.0, 0.0),
             lob: Vec2::new(1.0, 2.5).normalize() * 1.1,
+            roll: Vec2::new(0.4, -0.1),
             spin: 0.0,
         }
     }
@@ -104,6 +106,7 @@ impl ItemThrow {
             up: Self::standard().up * strength,
             drop: Self::standard().drop * strength,
             lob: Self::standard().lob * strength,
+            roll: Self::standard().roll * strength,
             spin: 0.0,
         }
     }
@@ -116,7 +119,11 @@ impl ItemThrow {
         let y = move_direction.y;
         let moving = move_direction.x.abs() > 0.0;
         if y < 0.0 {
-            return self.drop;
+            if moving {
+                return self.roll;
+            } else {
+                return self.drop;
+            }
         }
         if moving {
             if y > 0.0 {
@@ -168,7 +175,8 @@ fn throw_dropped_items(
             );
 
             body.velocity = throw_velocity * horizontal_flip_factor;
-            body.angular_velocity = item_throw.spin * if player_sprite.flip_x { -1.0 } else { 1.0 };
+            body.angular_velocity =
+                item_throw.spin * horizontal_flip_factor.x * throw_velocity.y.signum();
 
             body.is_deactivated = false;
         }

--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -155,7 +155,7 @@ fn throw_dropped_items(
         entities.iter_with((&items, &item_throws, &mut bodies))
     {
         if let Some(ItemDropped { player }) = items_dropped.remove(entity) {
-            commands.add(PlayerEvent::set_inventory(player, None));
+            commands.add(PlayerCommand::set_inventory(player, None));
             attachments.remove(entity);
 
             let player_sprite = sprites.get_mut(player).unwrap();

--- a/core/src/elements/crate_item.rs
+++ b/core/src/elements/crate_item.rs
@@ -136,7 +136,7 @@ fn update_idle_crates(
 
             if items_used.get(entity).is_some() {
                 items_used.remove(entity);
-                commands.add(PlayerEvent::set_inventory(player, None));
+                commands.add(PlayerCommand::set_inventory(player, None));
                 commands.add(
                     move |mut idle: CompMut<IdleCrate>, mut thrown: CompMut<ThrownCrate>| {
                         idle.remove(entity);
@@ -242,7 +242,7 @@ fn update_thrown_crates(
             .collect::<Vec<_>>();
 
         for player_entity in &colliding_with_players {
-            commands.add(PlayerEvent::kill(
+            commands.add(PlayerCommand::kill(
                 *player_entity,
                 Some(transform.translation.xy()),
             ));

--- a/core/src/elements/crate_item.rs
+++ b/core/src/elements/crate_item.rs
@@ -33,6 +33,7 @@ fn hydrate_crates(
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
     mut items: CompMut<Item>,
+    mut item_throws: CompMut<ItemThrow>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
@@ -53,6 +54,7 @@ fn hydrate_crates(
         let BuiltinElementKind::Crate{
             atlas,
             body_size,
+            throw_velocity,
             bounciness,
             ..
         } = &element_meta.builtin else{
@@ -64,6 +66,7 @@ fn hydrate_crates(
         let entity = entities.create();
         items.insert(entity, Item);
         idle_crates.insert(entity, IdleCrate);
+        item_throws.insert(entity, ItemThrow::strength(*throw_velocity));
         atlas_sprites.insert(entity, AtlasSprite::new(atlas.clone()));
         respawn_points.insert(entity, DehydrateOutOfBounds(spawner));
         transforms.insert(entity, transform);
@@ -89,17 +92,13 @@ fn update_idle_crates(
     entities: Res<Entities>,
     element_handles: Comp<ElementHandle>,
     element_assets: BevyAssets<ElementMeta>,
-    mut transforms: CompMut<Transform>,
-    mut idle_crates: CompMut<IdleCrate>,
-    mut sprites: CompMut<AtlasSprite>,
-    mut bodies: CompMut<KinematicBody>,
     mut items_used: CompMut<ItemUsed>,
-    mut items_dropped: CompMut<ItemDropped>,
+    mut idle_crates: CompMut<IdleCrate>,
+    mut bodies: CompMut<KinematicBody>,
     mut attachments: CompMut<PlayerBodyAttachment>,
     mut player_layers: CompMut<PlayerLayers>,
     player_inventories: PlayerInventories,
     mut commands: Commands,
-    mut player_events: ResMut<PlayerEvents>,
 ) {
     for (entity, (_idle_crate, element_handle)) in
         entities.iter_with((&mut idle_crates, &element_handles))
@@ -110,7 +109,6 @@ fn update_idle_crates(
 
         let BuiltinElementKind::Crate{
             grab_offset,
-            throw_velocity,
             fin_anim,
             ..
         } = &element_meta.builtin else {
@@ -138,28 +136,7 @@ fn update_idle_crates(
 
             if items_used.get(entity).is_some() {
                 items_used.remove(entity);
-                player_events.set_inventory(player, None);
-                attachments.remove(entity);
-
-                let player_velocity = bodies.get(player).unwrap().velocity;
-                let player_sprite = sprites.get_mut(player).unwrap();
-                let player_translation = transforms.get(player).unwrap().translation;
-
-                let body = bodies.get_mut(entity).unwrap();
-
-                let horizontal_flip_factor = if player_sprite.flip_x {
-                    Vec2::new(-1.0, 1.0)
-                } else {
-                    Vec2::ONE
-                };
-
-                body.velocity = *throw_velocity * horizontal_flip_factor + player_velocity;
-                body.is_deactivated = false;
-
-                let transform = transforms.get_mut(entity).unwrap();
-                transform.translation =
-                    player_translation + (*grab_offset * horizontal_flip_factor).extend(0.0);
-
+                commands.add(PlayerEvent::set_inventory(player, None));
                 commands.add(
                     move |mut idle: CompMut<IdleCrate>, mut thrown: CompMut<ThrownCrate>| {
                         idle.remove(entity);
@@ -176,37 +153,6 @@ fn update_idle_crates(
                 );
             }
         }
-
-        if let Some(dropped) = items_dropped.get(entity).copied() {
-            let player = dropped.player;
-
-            items_dropped.remove(entity);
-            attachments.remove(entity);
-
-            let player_translation = transforms.get(player).unwrap().translation;
-            let player_sprite = sprites.get_mut(player).unwrap();
-            let player_velocity = bodies.get(player).unwrap().velocity;
-
-            let body = bodies.get_mut(entity).unwrap();
-
-            body.is_deactivated = false;
-            body.is_spawning = true;
-
-            let horizontal_flip_factor = if player_sprite.flip_x {
-                Vec2::new(-1.0, 1.0)
-            } else {
-                Vec2::ONE
-            };
-
-            if player_velocity != Vec2::ZERO {
-                body.velocity =
-                    *throw_velocity / 5.0 * horizontal_flip_factor + player_velocity / 5.0;
-            }
-
-            let transform = transforms.get_mut(entity).unwrap();
-            transform.translation =
-                player_translation + (*grab_offset * horizontal_flip_factor).extend(0.0);
-        }
     }
 }
 
@@ -220,7 +166,6 @@ fn update_thrown_crates(
     mut atlas_sprites: CompMut<AtlasSprite>,
     players: Comp<PlayerIdx>,
     collision_world: CollisionWorld,
-    mut player_events: ResMut<PlayerEvents>,
     mut bodies: CompMut<KinematicBody>,
     mut audio_events: ResMut<AudioEvents>,
     transforms: Comp<Transform>,
@@ -297,7 +242,10 @@ fn update_thrown_crates(
             .collect::<Vec<_>>();
 
         for player_entity in &colliding_with_players {
-            player_events.kill(*player_entity, Some(transform.translation.xy()));
+            commands.add(PlayerEvent::kill(
+                *player_entity,
+                Some(transform.translation.xy()),
+            ));
         }
 
         if !colliding_with_players.is_empty()

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -21,6 +21,7 @@ pub struct LitKickBomb {
 fn hydrate(
     game_meta: Res<CoreMetaArc>,
     mut items: CompMut<Item>,
+    mut item_throws: CompMut<ItemThrow>,
     mut entities: ResMut<Entities>,
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
@@ -52,6 +53,8 @@ fn hydrate(
             body_diameter,
             can_rotate,
             bounciness,
+            throw_velocity,
+            angular_velocity,
             ..
         } = &element_meta.builtin
         {
@@ -59,6 +62,10 @@ fn hydrate(
 
             let entity = entities.create();
             items.insert(entity, Item);
+            item_throws.insert(
+                entity,
+                ItemThrow::strength(*throw_velocity).with_spin(*angular_velocity),
+            );
             idle_bombs.insert(entity, IdleKickBomb);
             atlas_sprites.insert(entity, AtlasSprite::new(atlas.clone()));
             respawn_points.insert(entity, DehydrateOutOfBounds(spawner_ent));
@@ -87,16 +94,13 @@ fn hydrate(
 fn update_idle_kick_bombs(
     entities: Res<Entities>,
     mut commands: Commands,
-    mut sprites: CompMut<AtlasSprite>,
     player_inventories: PlayerInventories,
     mut bodies: CompMut<KinematicBody>,
     mut items_used: CompMut<ItemUsed>,
-    mut transforms: CompMut<Transform>,
     mut audio_events: ResMut<AudioEvents>,
     element_handles: Comp<ElementHandle>,
     mut idle_bombs: CompMut<IdleKickBomb>,
     element_assets: BevyAssets<ElementMeta>,
-    mut items_dropped: CompMut<ItemDropped>,
     mut animated_sprites: CompMut<AnimatedSprite>,
     mut attachments: CompMut<PlayerBodyAttachment>,
     mut player_layers: CompMut<PlayerLayers>,
@@ -110,10 +114,8 @@ fn update_idle_kick_bombs(
 
         let BuiltinElementKind::KickBomb {
             grab_offset,
-            angular_velocity,
             fuse_sound,
             fuse_sound_volume,
-            throw_velocity,
             fin_anim,
             ..
         } = &element_meta.builtin else {
@@ -152,7 +154,6 @@ fn update_idle_kick_bombs(
                 animated_sprite.frames = Arc::from([3, 4, 5]);
                 animated_sprite.repeat = true;
                 animated_sprite.fps = 8.0;
-                body.angular_velocity = *angular_velocity;
                 commands.add(
                     move |mut idle: CompMut<IdleKickBomb>, mut lit: CompMut<LitKickBomb>| {
                         idle.remove(entity);
@@ -160,37 +161,6 @@ fn update_idle_kick_bombs(
                     },
                 );
             }
-        }
-
-        // If the item was dropped
-        if let Some(dropped) = items_dropped.get(entity).copied() {
-            let player = dropped.player;
-
-            items_dropped.remove(entity);
-            attachments.remove(entity);
-            let player_translation = transforms.get(dropped.player).unwrap().translation;
-            let player_velocity = bodies.get(player).unwrap().velocity;
-
-            let body = bodies.get_mut(entity).unwrap();
-            let player_sprite = sprites.get_mut(player).unwrap();
-
-            // Re-activate physics
-            body.is_deactivated = false;
-
-            let horizontal_flip_factor = if player_sprite.flip_x {
-                Vec2::new(-1.0, 1.0)
-            } else {
-                Vec2::ONE
-            };
-            body.velocity = *throw_velocity * horizontal_flip_factor + player_velocity;
-            body.angular_velocity =
-                *angular_velocity * if player_sprite.flip_x { -1.0 } else { 1.0 };
-
-            body.is_spawning = true;
-
-            let transform = transforms.get_mut(entity).unwrap();
-            transform.translation =
-                player_translation + (*grab_offset * horizontal_flip_factor).extend(0.0);
         }
     }
 }
@@ -206,7 +176,6 @@ fn update_lit_kick_bombs(
     mut lit_grenades: CompMut<LitKickBomb>,
     mut sprites: CompMut<AtlasSprite>,
     mut bodies: CompMut<KinematicBody>,
-    mut items_dropped: CompMut<ItemDropped>,
     mut hydrated: CompMut<MapElementHydrated>,
     mut attachments: CompMut<PlayerBodyAttachment>,
     mut player_layers: CompMut<PlayerLayers>,
@@ -224,10 +193,9 @@ fn update_lit_kick_bombs(
 
         let BuiltinElementKind::KickBomb {
             grab_offset,
-            angular_velocity,
             explosion_sound,
             explosion_volume,
-            throw_velocity,
+            kick_velocity,
             fuse_time,
             damage_region_lifetime,
             damage_region_size,
@@ -282,50 +250,19 @@ fn update_lit_kick_bombs(
             let player_standing_left = player_translation.x <= translation.x;
 
             if body.velocity.x == 0.0 {
-                body.velocity = *throw_velocity;
+                body.velocity = *kick_velocity;
                 if player_sprite.flip_x {
                     body.velocity.x *= -1.0;
                 }
             } else if player_standing_left && !player_sprite.flip_x {
-                body.velocity.x = throw_velocity.x;
-                body.velocity.y = throw_velocity.y;
+                body.velocity.x = kick_velocity.x;
+                body.velocity.y = kick_velocity.y;
             } else if !player_standing_left && player_sprite.flip_x {
-                body.velocity.x = -throw_velocity.x;
-                body.velocity.y = throw_velocity.y;
+                body.velocity.x = -kick_velocity.x;
+                body.velocity.y = kick_velocity.y;
             } else if kick_bomb.age >= *arm_delay {
                 should_explode = true;
             }
-        }
-
-        // If the item was dropped
-        if let Some(dropped) = items_dropped.get(entity).copied() {
-            let player = dropped.player;
-
-            items_dropped.remove(entity);
-            attachments.remove(entity);
-            let player_translation = transforms.get(dropped.player).unwrap().translation;
-            let player_velocity = bodies.get(player).unwrap().velocity;
-
-            let body = bodies.get_mut(entity).unwrap();
-            let player_sprite = sprites.get_mut(player).unwrap();
-
-            // Re-activate physics
-            body.is_deactivated = false;
-
-            let horizontal_flip_factor = if player_sprite.flip_x {
-                Vec2::new(-1.0, 1.0)
-            } else {
-                Vec2::ONE
-            };
-            body.velocity = *throw_velocity * horizontal_flip_factor + player_velocity;
-            body.angular_velocity =
-                *angular_velocity * if player_sprite.flip_x { -1.0 } else { 1.0 };
-
-            body.is_spawning = true;
-
-            let transform = transforms.get_mut(entity).unwrap();
-            transform.translation =
-                player_translation + (*grab_offset * horizontal_flip_factor).extend(0.0);
         }
 
         // If it's time to explode

--- a/core/src/elements/mine.rs
+++ b/core/src/elements/mine.rs
@@ -31,6 +31,7 @@ fn hydrate(
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
     mut items: CompMut<Item>,
+    mut item_throws: CompMut<ItemThrow>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
@@ -52,6 +53,7 @@ fn hydrate(
             atlas,
             body_size,
             bounciness,
+            throw_velocity,
             ..
         } = &element_meta.builtin
         {
@@ -61,6 +63,7 @@ fn hydrate(
             items.insert(entity, Item);
             idle_mines.insert(entity, IdleMine);
             atlas_sprites.insert(entity, AtlasSprite::new(atlas.clone()));
+            item_throws.insert(entity, ItemThrow::strength(*throw_velocity));
             respawn_points.insert(entity, DehydrateOutOfBounds(spawner_ent));
             transforms.insert(entity, transform);
             element_handles.insert(entity, element_handle.clone());
@@ -85,17 +88,13 @@ fn update_idle_mines(
     entities: Res<Entities>,
     element_handles: Comp<ElementHandle>,
     element_assets: BevyAssets<ElementMeta>,
-    mut transforms: CompMut<Transform>,
     mut idle_mines: CompMut<IdleMine>,
-    mut sprites: CompMut<AtlasSprite>,
     mut bodies: CompMut<KinematicBody>,
     mut items_used: CompMut<ItemUsed>,
-    mut items_dropped: CompMut<ItemDropped>,
     player_inventories: PlayerInventories,
     mut attachments: CompMut<PlayerBodyAttachment>,
     mut player_layers: CompMut<PlayerLayers>,
     mut commands: Commands,
-    mut player_events: ResMut<PlayerEvents>,
 ) {
     for (entity, (_mine, element_handle)) in entities.iter_with((&mut idle_mines, &element_handles))
     {
@@ -105,7 +104,6 @@ fn update_idle_mines(
 
         let BuiltinElementKind::Mine {
         grab_offset,
-        throw_velocity,
         fin_anim,
         ..
     } = &element_meta.builtin else {
@@ -138,27 +136,7 @@ fn update_idle_mines(
             // If the item is being used
             if items_used.get(entity).is_some() {
                 items_used.remove(entity);
-                player_events.set_inventory(player, None);
-                attachments.remove(entity);
-
-                let player_velocity = bodies.get(player).unwrap().velocity;
-                let player_sprite = sprites.get_mut(player).unwrap();
-                let player_translation = transforms.get(player).unwrap().translation;
-
-                let body = bodies.get_mut(entity).unwrap();
-
-                let horizontal_flip_factor = if player_sprite.flip_x {
-                    Vec2::new(-1.0, 1.0)
-                } else {
-                    Vec2::ONE
-                };
-
-                body.velocity = *throw_velocity * horizontal_flip_factor + player_velocity;
-                body.is_deactivated = false;
-
-                let transform = transforms.get_mut(entity).unwrap();
-                transform.translation =
-                    player_translation + (*grab_offset * horizontal_flip_factor).extend(0.0);
+                commands.add(PlayerEvent::set_inventory(player, None));
 
                 commands.add(
                     move |mut idle: CompMut<IdleMine>, mut thrown: CompMut<ThrownMine>| {
@@ -167,39 +145,6 @@ fn update_idle_mines(
                     },
                 );
             }
-        }
-
-        // If the item was dropped
-        if let Some(dropped) = items_dropped.get(entity).copied() {
-            let player = dropped.player;
-
-            items_dropped.remove(entity);
-            attachments.remove(entity);
-
-            let player_translation = transforms.get(dropped.player).unwrap().translation;
-            let player_velocity = bodies.get(player).unwrap().velocity;
-            let player_sprite = sprites.get_mut(player).unwrap();
-
-            let body = bodies.get_mut(entity).unwrap();
-
-            // Re-activate physics
-            body.is_deactivated = false;
-
-            let horizontal_flip_factor = if player_sprite.flip_x {
-                Vec2::new(-1.0, 1.0)
-            } else {
-                Vec2::ONE
-            };
-
-            if player_velocity != Vec2::ZERO {
-                body.velocity = *throw_velocity * horizontal_flip_factor + player_velocity;
-            }
-
-            body.is_spawning = true;
-
-            let transform = transforms.get_mut(entity).unwrap();
-            transform.translation =
-                player_translation + (*grab_offset * horizontal_flip_factor).extend(0.0);
         }
     }
 }
@@ -213,7 +158,6 @@ fn update_thrown_mines(
     mut animated_sprites: CompMut<AnimatedSprite>,
     mut hydrated: CompMut<MapElementHydrated>,
     player_indexes: Comp<PlayerIdx>,
-    mut player_events: ResMut<PlayerEvents>,
     mut commands: Commands,
     collision_world: CollisionWorld,
     transforms: Comp<Transform>,
@@ -268,7 +212,10 @@ fn update_thrown_mines(
             let mine_transform = *transforms.get(entity).unwrap();
 
             for player in &colliding_with_players {
-                player_events.kill(*player, Some(mine_transform.translation.xy()));
+                commands.add(PlayerEvent::kill(
+                    *player,
+                    Some(mine_transform.translation.xy()),
+                ));
             }
 
             audio_events.play(explosion_sound.clone(), *explosion_volume);

--- a/core/src/elements/mine.rs
+++ b/core/src/elements/mine.rs
@@ -136,7 +136,7 @@ fn update_idle_mines(
             // If the item is being used
             if items_used.get(entity).is_some() {
                 items_used.remove(entity);
-                commands.add(PlayerEvent::set_inventory(player, None));
+                commands.add(PlayerCommand::set_inventory(player, None));
 
                 commands.add(
                     move |mut idle: CompMut<IdleMine>, mut thrown: CompMut<ThrownMine>| {
@@ -212,7 +212,7 @@ fn update_thrown_mines(
             let mine_transform = *transforms.get(entity).unwrap();
 
             for player in &colliding_with_players {
-                commands.add(PlayerEvent::kill(
+                commands.add(PlayerCommand::kill(
                     *player,
                     Some(mine_transform.translation.xy()),
                 ));

--- a/core/src/elements/musket.rs
+++ b/core/src/elements/musket.rs
@@ -25,6 +25,7 @@ fn hydrate(
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
     mut items: CompMut<Item>,
+    mut item_throws: CompMut<ItemThrow>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
@@ -48,6 +49,8 @@ fn hydrate(
             body_size,
             can_rotate,
             bounciness,
+            throw_velocity,
+            angular_velocity,
             ..
         } = &element_meta.builtin
         {
@@ -55,6 +58,10 @@ fn hydrate(
 
             let entity = entities.create();
             items.insert(entity, Item);
+            item_throws.insert(
+                entity,
+                ItemThrow::strength(*throw_velocity).with_spin(*angular_velocity),
+            );
             muskets.insert(
                 entity,
                 Musket {
@@ -92,14 +99,14 @@ fn update(
     mut muskets: CompMut<Musket>,
     mut sprites: CompMut<AtlasSprite>,
     mut bodies: CompMut<KinematicBody>,
-    mut transforms: CompMut<Transform>,
+    transforms: CompMut<Transform>,
     mut audio_events: ResMut<AudioEvents>,
     mut player_layers: CompMut<PlayerLayers>,
 
     player_inventories: PlayerInventories,
     mut items_used: CompMut<ItemUsed>,
     mut attachments: CompMut<PlayerBodyAttachment>,
-    mut items_dropped: CompMut<ItemDropped>,
+    items_dropped: CompMut<ItemDropped>,
 ) {
     for (entity, (musket, element_handle)) in entities.iter_with((&mut muskets, &element_handles)) {
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -112,12 +119,9 @@ fn update(
             shoot_atlas,
             shoot_frames,
             shoot_lifetime,
-
-
+            
             fin_anim,
             grab_offset,
-            throw_velocity,
-            angular_velocity,
 
             bullet_meta,
             shoot_sound,
@@ -238,41 +242,9 @@ fn update(
         }
 
         // If the item was dropped
-        if let Some(dropped) = items_dropped.get(entity).copied() {
-            let player = dropped.player;
-
-            items_dropped.remove(entity);
-            attachments.remove(entity);
-
+        if items_dropped.get(entity).is_some() {
             // reload gun
             musket.ammo = *max_ammo;
-
-            let player_translation = transforms.get(dropped.player).unwrap().translation;
-            let player_velocity = bodies.get(player).unwrap().velocity;
-
-            let body = bodies.get_mut(entity).unwrap();
-            let player_sprite = sprites.get_mut(player).unwrap();
-
-            // Re-activate physics
-            body.is_deactivated = false;
-
-            let horizontal_flip_factor = if player_sprite.flip_x {
-                Vec2::new(-1.0, 1.0)
-            } else {
-                Vec2::ONE
-            };
-
-            if player_velocity != Vec2::ZERO {
-                body.velocity = *throw_velocity * horizontal_flip_factor + player_velocity;
-                body.angular_velocity =
-                    *angular_velocity * if player_sprite.flip_x { -1.0 } else { 1.0 };
-            }
-
-            body.is_spawning = true;
-
-            let transform = transforms.get_mut(entity).unwrap();
-            transform.translation =
-                player_translation + (*grab_offset * horizontal_flip_factor).extend(0.0);
         }
     }
 }

--- a/core/src/elements/musket.rs
+++ b/core/src/elements/musket.rs
@@ -119,10 +119,8 @@ fn update(
             shoot_atlas,
             shoot_frames,
             shoot_lifetime,
-            
             fin_anim,
             grab_offset,
-
             bullet_meta,
             shoot_sound,
             cooldown_frames,

--- a/core/src/elements/stomp_boots.rs
+++ b/core/src/elements/stomp_boots.rs
@@ -190,10 +190,10 @@ fn update(
 
 fn update_wearer(
     entities: Res<Entities>,
+    mut commands: Commands,
     wearing_stomp_boots: Comp<WearingStompBoots>,
     player_indexes: Comp<PlayerIdx>,
     collision_world: CollisionWorld,
-    mut player_events: ResMut<PlayerEvents>,
     kinematic_bodies: Comp<KinematicBody>,
     transforms: Comp<Transform>,
 ) {
@@ -221,7 +221,10 @@ fn update_wearer(
                         .center()
                         .y
                 {
-                    player_events.kill(player, Some(player_transform.translation.xy()))
+                    commands.add(PlayerEvent::kill(
+                        player,
+                        Some(player_transform.translation.xy()),
+                    ))
                 }
             });
     }

--- a/core/src/elements/stomp_boots.rs
+++ b/core/src/elements/stomp_boots.rs
@@ -221,7 +221,7 @@ fn update_wearer(
                         .center()
                         .y
                 {
-                    commands.add(PlayerEvent::kill(
+                    commands.add(PlayerCommand::kill(
                         player,
                         Some(player_transform.translation.xy()),
                     ))

--- a/core/src/elements/sword.rs
+++ b/core/src/elements/sword.rs
@@ -37,6 +37,7 @@ fn hydrate(
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
     mut items: CompMut<Item>,
+    mut item_throws: CompMut<ItemThrow>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
@@ -59,6 +60,8 @@ fn hydrate(
             body_size,
             can_rotate,
             bounciness,
+            throw_velocity,
+            angular_velocity,
             ..
         } = &element_meta.builtin
         {
@@ -66,6 +69,10 @@ fn hydrate(
 
             let entity = entities.create();
             items.insert(entity, Item);
+            item_throws.insert(
+                entity,
+                ItemThrow::strength(*throw_velocity).with_spin(*angular_velocity),
+            );
             swords.insert(entity, Sword::default());
             atlas_sprites.insert(entity, AtlasSprite::new(atlas.clone()));
             respawn_points.insert(entity, DehydrateOutOfBounds(spawner_ent));
@@ -102,14 +109,13 @@ fn update(
     mut sprites: CompMut<AtlasSprite>,
     mut bodies: CompMut<KinematicBody>,
     mut items_used: CompMut<ItemUsed>,
-    mut items_dropped: CompMut<ItemDropped>,
+    items_dropped: CompMut<ItemDropped>,
     mut attachments: CompMut<PlayerBodyAttachment>,
     player_indexes: Comp<PlayerIdx>,
     player_inventories: PlayerInventories,
-    mut player_events: ResMut<PlayerEvents>,
     mut commands: Commands,
     mut player_layers: CompMut<PlayerLayers>,
-    mut transforms: CompMut<Transform>,
+    transforms: CompMut<Transform>,
 ) {
     for (entity, (sword, element_handle)) in entities.iter_with((&mut swords, &element_handles)) {
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -139,8 +145,6 @@ fn update(
             sound,
             sound_volume,
             grab_offset,
-            throw_velocity,
-            angular_velocity,
             fin_anim,
             killing_speed,
             ..
@@ -280,45 +284,21 @@ fn update(
                         }
                     })
                     .for_each(|player| {
-                        player_events.kill(player, Some(sword_transform.translation.xy()))
+                        commands.add(PlayerEvent::kill(
+                            player,
+                            Some(sword_transform.translation.xy()),
+                        ))
                     });
             }
         }
 
         // If the item was dropped
-        if let Some(dropped) = items_dropped.get(entity).copied() {
-            attachments.remove(entity);
-            let player = dropped.player;
+        if items_dropped.get(entity).is_some() {
             sword.dropped_time = 0.0;
-
-            items_dropped.remove(entity);
-            let player_translation = transforms.get(dropped.player).unwrap().translation;
-            let player_velocity = bodies.get(player).unwrap().velocity;
-
-            let body = bodies.get_mut(entity).unwrap();
             let sprite = sprites.get_mut(entity).unwrap();
-
-            // Re-activate physics
-            body.is_deactivated = false;
 
             // Put sword in rest position
             sprite.index = 0;
-
-            let horizontal_flip_factor = if sprite.flip_x {
-                Vec2::new(-1.0, 1.0)
-            } else {
-                Vec2::ONE
-            };
-
-            if player_velocity != Vec2::ZERO {
-                body.velocity = *throw_velocity * horizontal_flip_factor + player_velocity;
-                body.angular_velocity = *angular_velocity * if sprite.flip_x { -1.0 } else { 1.0 };
-            }
-            body.is_spawning = true;
-
-            let transform = transforms.get_mut(entity).unwrap();
-            transform.translation = player_translation
-                + (vec2(grab_offset.x, 0.0) * horizontal_flip_factor).extend(0.0);
         }
     }
 }

--- a/core/src/elements/sword.rs
+++ b/core/src/elements/sword.rs
@@ -284,7 +284,7 @@ fn update(
                         }
                     })
                     .for_each(|player| {
-                        commands.add(PlayerEvent::kill(
+                        commands.add(PlayerCommand::kill(
                             player,
                             Some(sword_transform.translation.xy()),
                         ))

--- a/core/src/item.rs
+++ b/core/src/item.rs
@@ -1,5 +1,11 @@
 use crate::prelude::*;
 
+pub fn install(session: &mut GameSession) {
+    session
+        .stages
+        .add_system_to_stage(CoreStage::Last, throw_dropped_items);
+}
+
 /// Marker component for items.
 ///
 /// Items are any entity that players can pick up and use.
@@ -76,3 +82,123 @@ pub struct ItemGrabbed;
 #[derive(Clone, Copy, TypeUlid)]
 #[ulid = "01GP4DJ84TFB8Z7H9VY7Y0R47H"]
 pub struct ItemUsed;
+
+/// Component defining the strength of the throw types when an item is dropped.
+///
+/// Mainly handled by the [`throw_dropped_items`] system.
+#[derive(Clone, Copy, TypeUlid)]
+#[ulid = "01GSGE6N4TSEMQ1DKDP5Y66TE4"]
+pub struct ItemThrow {
+    normal: Vec2,
+    fast: Vec2,
+    up: Vec2,
+    drop: Vec2,
+    lob: Vec2,
+    roll: Vec2,
+    spin: f32,
+}
+
+impl ItemThrow {
+    /// The relative velocities of each different throw type.
+    ///
+    /// This is multiiplied by the desired throw strength in [`Self::strength`] to get a deafault
+    /// throw pattern from a single velocity.
+    pub fn base() -> Self {
+        Self {
+            normal: Vec2::new(1.5, 1.2).normalize() * 0.6,
+            fast: Vec2::new(1.5, 1.2).normalize(),
+            up: Vec2::new(0.0, 1.1),
+            drop: Vec2::new(0.0, 0.0),
+            lob: Vec2::new(1.0, 2.5).normalize() * 1.1,
+            roll: Vec2::new(0.4, -0.1),
+            spin: 0.0,
+        }
+    }
+
+    /// [`Self::base`] with the throw values multiplied by `strength`.
+    pub fn strength(strength: f32) -> Self {
+        let base = Self::base();
+        Self {
+            normal: base.normal * strength,
+            fast: base.fast * strength,
+            up: base.up * strength,
+            drop: base.drop * strength,
+            lob: base.lob * strength,
+            roll: base.roll * strength,
+            spin: 0.0,
+        }
+    }
+
+    pub fn with_spin(self, spin: f32) -> Self {
+        Self { spin, ..self }
+    }
+
+    /// Chooses one of the throw values based on a [`PlayerControl`]
+    pub fn velocity_from_control(&self, player_control: &PlayerControl) -> Vec2 {
+        let PlayerControl { move_direction, .. } = player_control;
+        let y = move_direction.y;
+        let moving = move_direction.x.abs() > 0.0;
+        if y < 0.0 {
+            if moving {
+                return self.roll;
+            } else {
+                return self.drop;
+            }
+        }
+        if moving {
+            if y > 0.0 {
+                self.lob
+            } else {
+                self.fast
+            }
+        } else if y > 0.0 {
+            self.up
+        } else {
+            self.normal
+        }
+    }
+}
+
+pub fn throw_dropped_items(
+    entities: Res<Entities>,
+    item_throws: Comp<ItemThrow>,
+    items: Comp<Item>,
+    player_inputs: Res<PlayerInputs>,
+    player_indexes: Comp<PlayerIdx>,
+    mut items_dropped: CompMut<ItemDropped>,
+    mut bodies: CompMut<KinematicBody>,
+    mut attachments: CompMut<PlayerBodyAttachment>,
+    mut sprites: CompMut<AtlasSprite>,
+    mut commands: Commands,
+) {
+    for (entity, (_items, item_throw, body)) in
+        entities.iter_with((&items, &item_throws, &mut bodies))
+    {
+        if let Some(ItemDropped { player }) = items_dropped.remove(entity) {
+            commands.add(PlayerCommand::set_inventory(player, None));
+            attachments.remove(entity);
+
+            let player_sprite = sprites.get_mut(player).unwrap();
+
+            let horizontal_flip_factor = if player_sprite.flip_x {
+                Vec2::new(-1.0, 1.0)
+            } else {
+                Vec2::ONE
+            };
+
+            let throw_velocity = item_throw.velocity_from_control(
+                &player_inputs
+                    .players
+                    .get(player_indexes.get(player).unwrap().0)
+                    .unwrap()
+                    .control,
+            );
+
+            body.velocity = throw_velocity * horizontal_flip_factor;
+            body.angular_velocity =
+                item_throw.spin * horizontal_flip_factor.x * throw_velocity.y.signum();
+
+            body.is_deactivated = false;
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -58,6 +58,7 @@ pub fn install_modules(session: &mut session::GameSession) {
     random::install(session);
     debug::install(session);
     attachment::install(session);
+    item::install(session);
     bullet::install(session);
     editor::install(session);
 }

--- a/core/src/map.rs
+++ b/core/src/map.rs
@@ -196,7 +196,7 @@ fn handle_out_of_bounds_players(
     for (player_ent, (_player_idx, transform)) in entities.iter_with((&player_indexes, &transforms))
     {
         if map.is_out_of_bounds(&transform.translation) {
-            commands.add(PlayerEvent::kill(player_ent, None));
+            commands.add(PlayerCommand::kill(player_ent, None));
         }
     }
 }

--- a/core/src/map.rs
+++ b/core/src/map.rs
@@ -188,15 +188,15 @@ fn spawn_map(
 
 fn handle_out_of_bounds_players(
     entities: Res<Entities>,
+    mut commands: Commands,
     transforms: CompMut<Transform>,
     player_indexes: Comp<PlayerIdx>,
     map: Res<LoadedMap>,
-    mut player_events: ResMut<PlayerEvents>,
 ) {
     for (player_ent, (_player_idx, transform)) in entities.iter_with((&player_indexes, &transforms))
     {
         if map.is_out_of_bounds(&transform.translation) {
-            player_events.kill(player_ent, None);
+            commands.add(PlayerEvent::kill(player_ent, None));
         }
     }
 }

--- a/core/src/metadata/element.rs
+++ b/core/src/metadata/element.rs
@@ -70,7 +70,7 @@ pub enum BuiltinElementKind {
         grab_offset: Vec2,
         damage_region_size: Vec2,
         damage_region_lifetime: f32,
-        throw_velocity: Vec2,
+        throw_velocity: f32,
         explosion_lifetime: f32,
         explosion_frames: usize,
         explosion_fps: f32,
@@ -133,7 +133,7 @@ pub enum BuiltinElementKind {
         angular_velocity: f32,
         can_rotate: bool,
         bounciness: f32,
-        throw_velocity: Vec2,
+        throw_velocity: f32,
         cooldown_frames: usize,
     },
     /// The throwable crate item
@@ -149,7 +149,7 @@ pub enum BuiltinElementKind {
         bounce_sound: Handle<AudioSource>,
         bounce_sound_volume: f32,
 
-        throw_velocity: Vec2,
+        throw_velocity: f32,
 
         body_size: Vec2,
         grab_offset: Vec2,
@@ -180,7 +180,7 @@ pub enum BuiltinElementKind {
         arm_sound_volume: f32,
         arm_sound: Handle<AudioSource>,
 
-        throw_velocity: Vec2,
+        throw_velocity: f32,
         body_size: Vec2,
         grab_offset: Vec2,
         fin_anim: Key,
@@ -200,7 +200,8 @@ pub enum BuiltinElementKind {
         grab_offset: Vec2,
         damage_region_size: Vec2,
         damage_region_lifetime: f32,
-        throw_velocity: Vec2,
+        kick_velocity: Vec2,
+        throw_velocity: f32,
         explosion_lifetime: f32,
         explosion_frames: usize,
         explosion_fps: f32,
@@ -232,7 +233,7 @@ pub enum BuiltinElementKind {
         body_size: Vec2,
         bounciness: f32,
         can_rotate: bool,
-        throw_velocity: Vec2,
+        throw_velocity: f32,
         angular_velocity: f32,
         atlas: Handle<Atlas>,
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -141,11 +141,11 @@ impl PlayerEvent {
     }
     /// Despawn a player.
     ///
-    /// > **Note:** This is different than the [`Kill`][Self::Kill] event in that it immediately
-    /// > removes the player from the world, while [`Kill`][Self::Kill] will usually cause the
+    /// > **Note:** This is different than the [`kill`][Self::kill] event in that it immediately
+    /// > removes the player from the world, while [`kill`][Self::kill] will usually cause the
     /// > player to enter the death animation.
     /// >
-    /// > [`Despawn`][Self::Despawn] is usually sent at the end of the player death animation.
+    /// > [`despawn`][Self::despawn] is usually sent at the end of the player death animation.
     pub fn despawn(player: Entity) -> System {
         (move |mut entities: ResMut<Entities>,
                attachments: Comp<Attachment>,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -102,9 +102,9 @@ pub struct PlayerKilled {
 
 /// Events that can be used to trigger player actions, such as killing, setting inventory, etc.
 #[derive(Clone, Debug)]
-pub struct PlayerEvent;
+pub struct PlayerCommand;
 
-impl PlayerEvent {
+impl PlayerCommand {
     /// Kill a player.
     ///
     /// > **Note:** This doesn't despawn the player, it just puts the player into it's death animation.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use crate::{item::ItemGrabbed, physics::KinematicBody, prelude::*};
 
 mod state;
@@ -13,7 +11,6 @@ pub fn install(session: &mut GameSession) {
     session
         .stages
         .add_system_to_stage(CoreStage::First, hydrate_players)
-        .add_system_to_stage(CoreStage::PostUpdate, handle_player_events)
         .add_system_to_stage(CoreStage::PostUpdate, play_itemless_fin_animations)
         .add_system_to_stage(CoreStage::PostUpdate, player_facial_animations)
         .add_system_to_stage(CoreStage::Last, update_player_layers);
@@ -103,51 +100,45 @@ pub struct PlayerKilled {
     pub hit_from: Option<Vec2>,
 }
 
-/// Resource containing the player event queue.
-#[derive(Clone, TypeUlid, Debug, Default)]
-#[ulid = "01GP49AK25A8S9G2GYNAVE4PTN"]
-pub struct PlayerEvents {
-    pub queue: VecDeque<PlayerEvent>,
-}
-
-impl PlayerEvents {
-    /// Send a player event.
-    pub fn send(&mut self, event: PlayerEvent) {
-        self.queue.push_back(event);
-    }
-
-    #[inline]
-    pub fn set_inventory(&mut self, player: Entity, item: Option<Entity>) {
-        self.queue
-            .push_back(PlayerEvent::SetInventory { player, item })
-    }
-
-    #[inline]
-    pub fn use_item(&mut self, player: Entity) {
-        self.queue.push_back(PlayerEvent::UseItem { player })
-    }
-
-    #[inline]
-    pub fn kill(&mut self, player: Entity, hit_from: Option<Vec2>) {
-        self.queue.push_back(PlayerEvent::Kill { player, hit_from })
-    }
-
-    #[inline]
-    pub fn despawn(&mut self, player: Entity) {
-        self.queue.push_back(PlayerEvent::Despawn { player })
-    }
-}
-
 /// Events that can be used to trigger player actions, such as killing, setting inventory, etc.
 #[derive(Clone, Debug)]
-pub enum PlayerEvent {
+pub struct PlayerEvent;
+
+impl PlayerEvent {
     /// Kill a player.
     ///
     /// > **Note:** This doesn't despawn the player, it just puts the player into it's death animation.
-    Kill {
-        player: Entity,
-        hit_from: Option<Vec2>,
-    },
+    pub fn kill(player: Entity, hit_from: Option<Vec2>) -> System {
+        (move |mut players_killed: CompMut<PlayerKilled>,
+               mut items_dropped: CompMut<ItemDropped>,
+               mut inventories: CompMut<Inventory>,
+               player_indexes: Comp<PlayerIdx>| {
+            if players_killed.contains(player) {
+                // No need to kill him again
+                return;
+            }
+
+            let Some(idx) = player_indexes.get(player) else {
+                    // Not a player, just ignore it.
+                    warn!("Tried to kill non-player entity.");
+                    return;
+                };
+
+            debug!("Killing player: {}", idx.0);
+
+            // Drop any items the player was carrying
+            let inventory = inventories.get(player).cloned().unwrap_or_default();
+            if let Some(item) = inventory.0 {
+                items_dropped.insert(item, ItemDropped { player });
+            }
+
+            // Update the inventory
+            inventories.insert(player, Inventory(None));
+
+            players_killed.insert(player, PlayerKilled { hit_from });
+        })
+        .system()
+    }
     /// Despawn a player.
     ///
     /// > **Note:** This is different than the [`Kill`][Self::Kill] event in that it immediately
@@ -155,94 +146,63 @@ pub enum PlayerEvent {
     /// > player to enter the death animation.
     /// >
     /// > [`Despawn`][Self::Despawn] is usually sent at the end of the player death animation.
-    Despawn { player: Entity },
+    pub fn despawn(player: Entity) -> System {
+        (move |mut entities: ResMut<Entities>,
+               attachments: Comp<Attachment>,
+               player_indexes: Comp<PlayerIdx>,
+               player_layers: Comp<PlayerLayers>| {
+            if player_indexes.contains(player) {
+                entities
+                    .iter_with(&attachments)
+                    .filter(|(_, attachment)| attachment.entity == player)
+                    .map(|(entity, _)| entity)
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .for_each(|entity| {
+                        entities.kill(*entity);
+                    });
+                let layers = player_layers.get(player).unwrap();
+                entities.kill(layers.fin_ent);
+                entities.kill(layers.face_ent);
+                entities.kill(player);
+            } else {
+                warn!("Tried to despawn non-player entity.");
+            }
+        })
+        .system()
+    }
     /// Set the player's inventory
-    SetInventory {
-        player: Entity,
-        item: Option<Entity>,
-    },
+    pub fn set_inventory(player: Entity, item: Option<Entity>) -> System {
+        (move |mut items_grabbed: CompMut<ItemGrabbed>,
+               mut items_dropped: CompMut<ItemDropped>,
+               mut inventories: CompMut<Inventory>| {
+            let inventory = inventories.get(player).cloned().unwrap_or_default();
+
+            // If there was a previous item, drop it
+            if let Some(item) = inventory.0 {
+                items_dropped.insert(item, ItemDropped { player });
+            }
+
+            // If there is a new item, grab it
+            if let Some(item) = item {
+                items_grabbed.insert(item, ItemGrabbed);
+            }
+
+            // Update the inventory
+            inventories.insert(player, Inventory(item));
+        })
+        .system()
+    }
     /// Have the player use the item they are carrying, if any.
-    UseItem { player: Entity },
-}
-
-fn handle_player_events(
-    mut entities: ResMut<Entities>,
-    mut player_events: ResMut<PlayerEvents>,
-    mut players_killed: CompMut<PlayerKilled>,
-    mut items_grabbed: CompMut<ItemGrabbed>,
-    mut items_dropped: CompMut<ItemDropped>,
-    mut items_used: CompMut<ItemUsed>,
-    mut inventories: CompMut<Inventory>,
-    attachments: Comp<Attachment>,
-    player_indexes: Comp<PlayerIdx>,
-    player_layers: Comp<PlayerLayers>,
-) {
-    while let Some(event) = player_events.queue.pop_front() {
-        match event {
-            PlayerEvent::Kill { player, hit_from } => {
-                if players_killed.contains(player) {
-                    // No need to kill him again
-                    continue;
-                }
-
-                let Some(idx) = player_indexes.get(player) else {
-                    // Not a player, just ignore it.
-                    warn!("Tried to kill non-player entity.");
-                    continue;
-                };
-
-                debug!("Killing player: {}", idx.0);
-
-                // Drop any items the player was carrying
-                player_events
-                    .queue
-                    .push_front(PlayerEvent::SetInventory { player, item: None });
-
-                players_killed.insert(player, PlayerKilled { hit_from });
+    pub fn use_item(player: Entity) -> System {
+        (move |mut items_used: CompMut<ItemUsed>, inventories: CompMut<Inventory>| {
+            // If the player has an item
+            if let Some(item) = inventories.get(player).and_then(|x| x.0) {
+                // Use it
+                items_used.insert(item, ItemUsed);
             }
-            PlayerEvent::Despawn { player } => {
-                if player_indexes.contains(player) {
-                    entities
-                        .iter_with(&attachments)
-                        .filter(|(_, attachment)| attachment.entity == player)
-                        .map(|(entity, _)| entity)
-                        .collect::<Vec<_>>()
-                        .iter()
-                        .for_each(|entity| {
-                            entities.kill(*entity);
-                        });
-                    let layers = player_layers.get(player).unwrap();
-                    entities.kill(layers.fin_ent);
-                    entities.kill(layers.face_ent);
-                    entities.kill(player);
-                } else {
-                    warn!("Tried to despawn non-player entity.");
-                }
-            }
-            PlayerEvent::SetInventory { player, item } => {
-                let inventory = inventories.get(player).cloned().unwrap_or_default();
-
-                // If there was a previous item, drop it
-                if let Some(item) = inventory.0 {
-                    items_dropped.insert(item, ItemDropped { player });
-                }
-
-                // If there is a new item, grab it
-                if let Some(item) = item {
-                    items_grabbed.insert(item, ItemGrabbed);
-                }
-
-                // Update the inventory
-                inventories.insert(player, Inventory(item));
-            }
-            PlayerEvent::UseItem { player } => {
-                // If the player has an item
-                if let Some(item) = inventories.get(player).and_then(|x| x.0) {
-                    // Use it
-                    items_used.insert(item, ItemUsed);
-                }
-            }
-        }
+        })
+        .system()
     }
 }
 

--- a/core/src/player/state.rs
+++ b/core/src/player/state.rs
@@ -83,7 +83,7 @@ fn use_drop_or_grab_items(
             // Grab the first item we are touching
             if let Some(item) = colliders.get(0) {
                 // Add the item to the player inventory
-                commands.add(PlayerEvent::set_inventory(player_ent, Some(*item)));
+                commands.add(PlayerCommand::set_inventory(player_ent, Some(*item)));
 
                 // Play grab sound
                 audio_events.play(meta.sounds.grab.clone(), meta.sounds.grab_volume);
@@ -92,7 +92,7 @@ fn use_drop_or_grab_items(
         // If we are already carrying an item
         } else {
             // Drop it
-            commands.add(PlayerEvent::set_inventory(player_ent, None));
+            commands.add(PlayerCommand::set_inventory(player_ent, None));
 
             // Play drop sound
             audio_events.play(meta.sounds.drop.clone(), meta.sounds.drop_volume);
@@ -101,6 +101,6 @@ fn use_drop_or_grab_items(
 
     // If we are using an item
     if control.shoot_just_pressed && inventory.is_some() {
-        commands.add(PlayerEvent::use_item(player_ent));
+        commands.add(PlayerCommand::use_item(player_ent));
     }
 }

--- a/core/src/player/state.rs
+++ b/core/src/player/state.rs
@@ -63,8 +63,8 @@ fn use_drop_or_grab_items(
     collision_world: &CollisionWorld,
     items: &Comp<Item>,
     held_items: &[Entity],
-    player_events: &mut PlayerEvents,
     audio_events: &mut AudioEvents,
+    commands: &mut Commands,
 ) {
     // If we are grabbing
     if control.grab_just_pressed {
@@ -83,7 +83,7 @@ fn use_drop_or_grab_items(
             // Grab the first item we are touching
             if let Some(item) = colliders.get(0) {
                 // Add the item to the player inventory
-                player_events.set_inventory(player_ent, Some(*item));
+                commands.add(PlayerEvent::set_inventory(player_ent, Some(*item)));
 
                 // Play grab sound
                 audio_events.play(meta.sounds.grab.clone(), meta.sounds.grab_volume);
@@ -92,7 +92,7 @@ fn use_drop_or_grab_items(
         // If we are already carrying an item
         } else {
             // Drop it
-            player_events.set_inventory(player_ent, None);
+            commands.add(PlayerEvent::set_inventory(player_ent, None));
 
             // Play drop sound
             audio_events.play(meta.sounds.drop.clone(), meta.sounds.drop_volume);
@@ -101,6 +101,6 @@ fn use_drop_or_grab_items(
 
     // If we are using an item
     if control.shoot_just_pressed && inventory.is_some() {
-        player_events.use_item(player_ent);
+        commands.add(PlayerEvent::use_item(player_ent));
     }
 }

--- a/core/src/player/state/states/crouch.rs
+++ b/core/src/player/state/states/crouch.rs
@@ -30,12 +30,25 @@ pub fn handle_player_state(
     player_indexes: Comp<PlayerIdx>,
     mut animations: CompMut<AnimationBankSprite>,
     mut bodies: CompMut<KinematicBody>,
+    player_assets: BevyAssets<PlayerMeta>,
+    mut inventories: CompMut<Inventory>,
+    items: Comp<Item>,
+    mut audio_events: ResMut<AudioEvents>,
+    collision_world: CollisionWorld,
+    mut commands: Commands,
 ) {
-    for (_ent, (state, player_idx, animation, body)) in entities.iter_with((
+    // Collect a list of items that are being held by players
+    let held_items = entities
+        .iter_with(&inventories)
+        .filter_map(|(_ent, inventory)| inventory.0)
+        .collect::<Vec<_>>();
+
+    for (player_ent, (state, player_idx, animation, body, inventory)) in entities.iter_with((
         &player_states,
         &player_indexes,
         &mut animations,
         &mut bodies,
+        &mut inventories,
     )) {
         if state.current != ID {
             continue;
@@ -50,5 +63,24 @@ pub fn handle_player_state(
         if control.jump_just_pressed {
             body.fall_through = true;
         }
+
+        let meta_handle = player_inputs.players[player_idx.0]
+            .selected_player
+            .get_bevy_handle();
+        let Some(meta) = player_assets.get(&meta_handle) else {
+            continue;
+        };
+
+        use_drop_or_grab_items(
+            player_ent,
+            meta,
+            control,
+            inventory,
+            &collision_world,
+            &items,
+            &held_items,
+            &mut audio_events,
+            &mut commands,
+        );
     }
 }

--- a/core/src/player/state/states/dead.rs
+++ b/core/src/player/state/states/dead.rs
@@ -47,7 +47,7 @@ pub fn handle_player_state(
         }
 
         if state.age >= 80 {
-            commands.add(PlayerEvent::despawn(player_ent));
+            commands.add(PlayerCommand::despawn(player_ent));
         }
     }
 }

--- a/core/src/player/state/states/dead.rs
+++ b/core/src/player/state/states/dead.rs
@@ -14,12 +14,12 @@ pub fn player_state_transition(
 
 pub fn handle_player_state(
     entities: Res<Entities>,
+    mut commands: Commands,
     player_states: Comp<PlayerState>,
     killed_players: Comp<PlayerKilled>,
     sprites: Comp<AtlasSprite>,
     transform: Comp<Transform>,
     mut animations: CompMut<AnimationBankSprite>,
-    mut player_events: ResMut<PlayerEvents>,
 ) {
     for (player_ent, (state, animation, killed_player)) in
         entities.iter_with((&player_states, &mut animations, &killed_players))
@@ -47,7 +47,7 @@ pub fn handle_player_state(
         }
 
         if state.age >= 80 {
-            player_events.despawn(player_ent);
+            commands.add(PlayerEvent::despawn(player_ent));
         }
     }
 }

--- a/core/src/player/state/states/idle.rs
+++ b/core/src/player/state/states/idle.rs
@@ -38,9 +38,9 @@ pub fn handle_player_state(
     mut sprites: CompMut<AnimationBankSprite>,
     mut bodies: CompMut<KinematicBody>,
     items: Comp<Item>,
-    mut player_events: ResMut<PlayerEvents>,
     mut audio_events: ResMut<AudioEvents>,
     collision_world: CollisionWorld,
+    mut commands: Commands,
 ) {
     // Collect a list of items that are being held by players
     let held_items = entities
@@ -82,8 +82,8 @@ pub fn handle_player_state(
             &collision_world,
             &items,
             &held_items,
-            &mut player_events,
             &mut audio_events,
+            &mut commands,
         );
 
         // If we are jumping

--- a/core/src/player/state/states/midair.rs
+++ b/core/src/player/state/states/midair.rs
@@ -44,9 +44,9 @@ pub fn handle_player_state(
     mut animations: CompMut<AnimationBankSprite>,
     mut bodies: CompMut<KinematicBody>,
     items: Comp<Item>,
-    mut player_events: ResMut<PlayerEvents>,
     mut audio_events: ResMut<AudioEvents>,
     collision_world: CollisionWorld,
+    mut commands: Commands,
 ) {
     // Collect a list of items that are being held by players
     let held_items = entities
@@ -88,8 +88,8 @@ pub fn handle_player_state(
             &collision_world,
             &items,
             &held_items,
-            &mut player_events,
             &mut audio_events,
+            &mut commands,
         );
 
         // Limit fall speed if holding jump button

--- a/core/src/player/state/states/walk.rs
+++ b/core/src/player/state/states/walk.rs
@@ -39,9 +39,9 @@ pub fn handle_player_state(
     mut animations: CompMut<AnimationBankSprite>,
     mut bodies: CompMut<KinematicBody>,
     items: Comp<Item>,
-    mut player_events: ResMut<PlayerEvents>,
     mut audio_events: ResMut<AudioEvents>,
     collision_world: CollisionWorld,
+    mut commands: Commands,
 ) {
     // Collect a list of items that are being held by players
     let held_items = entities
@@ -82,8 +82,8 @@ pub fn handle_player_state(
             &collision_world,
             &items,
             &held_items,
-            &mut player_events,
             &mut audio_events,
+            &mut commands,
         );
 
         // If we are jumping

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,8 +1,8 @@
 pub use {
     crate::{
         attachment::*, bullet::*, camera::*, damage::*, debug::*, debug::*, elements::*, input::*,
-        item::*, lifetime::*, map::*, math::*, metadata::*, physics::*, player::*, session::*,
-        MAX_PLAYERS,
+        item::*, item::*, lifetime::*, map::*, math::*, metadata::*, physics::*, player::*,
+        session::*, MAX_PLAYERS,
     },
     bones_bevy_asset::{BevyAssets, BonesBevyAsset, BonesBevyAssetLoad},
     bones_lib::prelude::*,


### PR DESCRIPTION
Add differing throw types and add their functionality to the
current item selection.

Convert the PlayerEvent enum into a struct with systems for use in
Commands. This replaces the handle_player_events system because of
timing issues.

Closes: #628