### PR TITLE
[Merged by Bors] - chore: increase default optimization level during development.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,11 +76,11 @@ debug = 1 # Only keep line numbers
 
 # Optimize our code a little bit.
 [profile.dev.package.jumpy_core]
-opt-level = 0
+opt-level = 1
 codegen-units = 512
 
 [profile.dev]
-opt-level = 0
+opt-level = 1
 codegen-units = 128
 
 [profile.dev-optimized]


### PR DESCRIPTION
It seems that we need at least a little optimization
for good performance during development.

This can still be turned down by developers if they
need maximum compile speed.