### PR TITLE
[Merged by Bors] - fix: fix ship_decorations tilemap.

### DIFF
--- a/assets/map/resources/ship_decorations.atlas.yaml
+++ b/assets/map/resources/ship_decorations.atlas.yaml
@@ -1,4 +1,4 @@
 image: ./ship_decorations.png
 tile_size: [32, 32]
-columns: 32
-rows: 10
+columns: 11
+rows: 5


### PR DESCRIPTION
The atlas size was incorrectly set in the YAML,
causing it to behave strangely.