### PR TITLE
[Merged by Bors] - ci: make nightly releases 4 hours later.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: 🚀 Release
 on:
   schedule:
     # Run every night
-    - cron: "0 0 * * *"
+    - cron: "0 4 * * *"
   workflow_dispatch:
   push:
     tags:


### PR DESCRIPTION
This puts it more in line with the development cycle
for the US Central time zone that I'm in.