### PR TITLE
[Merged by Bors] - fix(web): prevent default browser context menu behavior.

### DIFF
--- a/wasm_resources/index.html
+++ b/wasm_resources/index.html
@@ -133,6 +133,17 @@
     <script type="module">
       import init from "./jumpy.js";
       init();
+      const ignoreCanvasContextMenu = () => {
+        const canvases = document.getElementsByTagName('canvas');
+        if (canvases[0]) {
+            canvases[0].oncontextmenu = (e) => {
+                e.preventDefault()
+            };
+        } else {
+            setTimeout(ignoreCanvasContextMenu, 1000)
+        }
+      };
+      setTimeout(ignoreCanvasContextMenu, 1000)
     </script>
   </body>
 </html>


### PR DESCRIPTION
This fixes the editor right-click behaviors by preventing
the default browser behavior when clicking on the canvas.