### PR TITLE
ci: use independent cache for docs build in CI.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
           path: |
             target/
             web-target/
-          key: Linux-cargo-target-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-doc-${{ hashFiles('**/Cargo.lock') }}
 
       - name: 🔨 Build Rustdoc
         run: |


### PR DESCRIPTION
Hopefully this will improve the docs build time in CI which
seems to be longer than it should be.