### PR TITLE
ci: update CI caches.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         config:
           - { target: "x86_64-unknown-linux-gnu", target_dir: "target" }
-          - { target: 'wasm32-unknown-unknown', target_dir: 'web-target' }
+          - { target: "wasm32-unknown-unknown", target_dir: "web-target" }
     steps:
       - name: ⬇️ Checkout Source
         uses: actions/checkout@v3
@@ -59,19 +59,13 @@ jobs:
         with:
           components: clippy
 
-      - name: ♻️ Cache Cargo Registry
+      - name: ♻️ Cache Cargo
         uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: cargo-registry
-
-      - name: ♻️ Cache Cargo Target
-        uses: actions/cache@v3
-        with:
-          path: |
             target/
             web-target/
           key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}
@@ -97,7 +91,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
-      with:
-        command: check ${{ matrix.checks }}
+      - uses: actions/checkout@v3
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check ${{ matrix.checks }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,17 +31,12 @@ jobs:
           mdbook-version: "0.4.22"
 
       - uses: actions/cache@v3
-        name: ♻️ Cache Cargo Registry
+        name: ♻️ Cache Cargo
         with:
           path: |
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: cargo-registry
-      - uses: actions/cache@v3
-        name: ♻️ Cache Cargo Target
-        with:
-          path: |
             target/
             web-target/
           key: cargo-doc-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "args=--latest" >> $GITHUB_OUTPUT
-          else 
+          else
             echo "args=--unreleased" >> $GITHUB_OUTPUT
           fi
 
@@ -86,15 +86,6 @@ jobs:
           override: true
           profile: minimal
           target: ${{ matrix.config.target }}
-
-      - uses: actions/cache@v3
-        name: ♻️ Cache Cargo Registry
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-registry
 
       - name: 🔨 Build
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
This updates each CI workflow to use it's own cache key. It appears that trying to re-use caches across workflows doesn't work properly.

This also removes the caching from the release workflow which will only run for nightly releases and tagged releases so we don't need to waste the cache space when we can afford to just wait for the builds.