### PR TITLE
ci: adjust CI caches to avoid cache misses.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
             ~/.cargo/git/db/
             target/
             web-target/
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ci-${{ matrix.config.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ci-${{ matrix.config.target }}-
 
       - name: 🔧 Check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,9 @@ jobs:
             ~/.cargo/git/db/
             target/
             web-target/
-          key: cargo-doc-${{ hashFiles('**/Cargo.lock') }}
+          key: docs-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            docs-
 
       - name: 🔨 Build Rustdoc
         run: |

--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -21,15 +21,6 @@ jobs:
       - name: 🧰 Install Just
         run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
 
-      - name: ♻ ️Cargo Registry Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: cargo-registry
-
       - name: 🦀 Install Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -41,6 +32,19 @@ jobs:
         name: 🔧 Wasm Bindgen
         with:
           version: "0.2.84"
+
+      - uses: actions/cache@v3
+        name: ♻️ Cache Cargo
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+            web-target/
+          key: web-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            web-release-
 
       - name: 🔨 Build WASM Release
         run: just build-release-web


### PR DESCRIPTION
GitHub changed the rules for CI caches at some point so that they can not be changed after being created. This takes that into account and uses a different cache for different platform + Cargo.lock combinations.