### PR TITLE
changed session.rs so ai player cannot be controled.

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -147,6 +147,9 @@ fn update_input(
         inputs.players[0].editor_input = editor_input.take();
 
         for (player_idx, action_state) in &player_input_collectors {
+
+            if inputs.players[ player_idx.0].is_ai { continue;}
+
             let control = &mut inputs.players[player_idx.0].control;
 
             let jump_pressed = action_state.pressed(PlayerAction::Jump);


### PR DESCRIPTION
Updates based on issue #712. 

1. Tested both online demo and launched game from my terminal to see how I could control ai player. Generally it was through the `jump` key, and sometimes the `left` and `right` keys, but to a lesser extent. 
2. Updated session.rs `line 151` to stop receiving user input. 

Does this project require tests being added to make sure the code is correct / stable?

If so I can try and add that to my PR. Please lmk if any additional changes are required. 

Thanks!