### PR TITLE
fix: fix z layering for items and fish so they don't interpenetrate.

### DIFF
--- a/core/src/elements/grenade.rs
+++ b/core/src/elements/grenade.rs
@@ -240,7 +240,7 @@ fn update_lit_grenades(
             // Cause the item to respawn by un-hydrating it's spawner.
             hydrated.remove(**spawner);
             let mut explosion_transform = *transforms.get(entity).unwrap();
-            explosion_transform.translation.z += 1.0;
+            explosion_transform.translation.z = -10.0; // On top of almost everything
             explosion_transform.rotation = Quat::IDENTITY;
 
             // Clone types for move into closure

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -255,7 +255,7 @@ fn update_lit_kick_bombs(
             // Cause the item to respawn by un-hydrating it's spawner.
             hydrated.remove(**spawner);
             let mut explosion_transform = *transforms.get(entity).unwrap();
-            explosion_transform.translation.z += 1.0;
+            explosion_transform.translation.z = -10.0; // On top of almost everything
             explosion_transform.rotation = Quat::IDENTITY;
 
             // Clone types for move into closure

--- a/core/src/elements/mine.rs
+++ b/core/src/elements/mine.rs
@@ -214,6 +214,7 @@ fn update_thrown_mines(
                       mut sprites: CompMut<AtlasSprite>,
                       mut animated_sprites: CompMut<AnimatedSprite>| {
                     let mut explosion_transform = mine_transform;
+                    explosion_transform.translation.z = -10.0; // On top of almost everything
                     explosion_transform.rotation = Quat::IDENTITY;
 
                     // Despawn the grenade

--- a/core/src/elements/player_spawner.rs
+++ b/core/src/elements/player_spawner.rs
@@ -72,8 +72,9 @@ fn update(
 
             let Some(mut spawn_point) = spawn_points.get(current_spawner.0).copied() else { return };
 
-            // Make sure each player spawns at a different z level
-            spawn_point.z += i as f32 * 0.1;
+            // Make sure each player spawns at a different z level ( give enough room for 10 players
+            // to fit between map layers )
+            spawn_point.z += i as f32 * MAP_LAYERS_GAP_DEPTH / 10.0;
 
             let player_ent = entities.create();
             player_indexes.insert(player_ent, PlayerIdx(i));

--- a/core/src/map.rs
+++ b/core/src/map.rs
@@ -24,10 +24,15 @@ pub struct LoadedMap(pub Arc<MapMeta>);
 #[ulid = "01GP3Z38HKE37JB6GRHHPPTY38"]
 pub struct MapSpawned(pub bool);
 
+/// The Z depth of the deepest map layer.
+pub const MAP_LAYERS_MIN_DEPTH: f32 = -900.0;
+/// The Z depth in between each map layer.
+pub const MAP_LAYERS_GAP_DEPTH: f32 = 10.0;
+
 /// Helper for getting the z-depth of the map layer with the given index.
 pub fn z_depth_for_map_layer(layer_idx: usize) -> f32 {
-    // We start map layers at -900 and for ever layer we place a gap of 2 units in between
-    -900.0 + layer_idx as f32 * 2.0
+    // We start map layers at -900 and for ever layer we place a gap of 10 units in between
+    MAP_LAYERS_MIN_DEPTH + layer_idx as f32 * MAP_LAYERS_GAP_DEPTH
 }
 
 /// Resource containing essential the map metadata for the map once spawned. This allows the

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -37,7 +37,8 @@ pub struct PlayerLayers {
 }
 
 impl PlayerLayers {
-    pub const FIN_Z_OFFSET: f32 = 2.0;
+    pub const FIN_Z_OFFSET: f32 = 0.5;
+    pub const FACE_Z_OFFSET: f32 = 0.01;
 }
 
 /// A component representing the current emote state of a player.
@@ -501,7 +502,7 @@ fn hydrate_players(
             face_entity,
             PlayerBodyAttachment {
                 player: player_entity,
-                offset: meta.layers.face.offset.extend(0.01),
+                offset: meta.layers.face.offset.extend(PlayerLayers::FACE_Z_OFFSET),
                 sync_animation: false,
             },
         );


### PR DESCRIPTION
This prevents players fins from sticking out of other players bodies when they stand over each-other, and it fixes dropped items from fitting between the player's face and the player's body.

Closes: #716