### PR TITLE
fix: prevent bullet from killing shooter.

### DIFF
--- a/core/src/bullet.rs
+++ b/core/src/bullet.rs
@@ -14,12 +14,7 @@ pub fn install(session: &mut GameSession) {
 #[ulid = "01GQX3KM2A4WPV2NKJNG85TJ3P"]
 pub struct Bullet {
     pub direction: f32,
-}
-
-impl Default for Bullet {
-    fn default() -> Self {
-        Self { direction: 1.0 }
-    }
+    pub owner: Entity,
 }
 
 /// Component containing the bullet's metadata handle.
@@ -120,6 +115,7 @@ fn update(
                 player_indexes.contains(e) && invincibles.get(e).is_none()
             })
             .into_iter()
+            .filter(|player| *player != bullet.owner)
             .for_each(|player| {
                 hit_player = true;
                 commands.add(PlayerCommand::kill(player, Some(position.translation.xy())));

--- a/core/src/elements/musket.rs
+++ b/core/src/elements/musket.rs
@@ -221,6 +221,7 @@ fn update(
                             bullets.insert(
                                 ent,
                                 Bullet {
+                                    owner: player,
                                     direction: if player_flip_x { -1.0 } else { 1.0 },
                                 },
                             );


### PR DESCRIPTION
This fixes #715. Issue suggested that what should be done is adding owner to damage region (as is done in case of sword), however it seems that bullet does not use those regions so I simply add entity marker to bullet object and filter out all collisions with this entity.