### PR TITLE
fix: updated default.core.yaml to make camera padding larger

### DIFF
--- a/assets/default.core.yaml
+++ b/assets/default.core.yaml
@@ -3,8 +3,8 @@ config:
 
 camera:
   default_height: 448
-  border_right: 75
-  border_left: 75
+  border_right: 80
+  border_left: 80
   border_top: 50
   border_bottom: 200
   player_camera_box_size: [100, 250]


### PR DESCRIPTION
Updated the camera padding in `default.core.yaml` to make view wider, especially on level 6. 
<img width="1278" alt="Screenshot 2023-03-16 at 8 01 46 PM" src="https://user-images.githubusercontent.com/24905907/225779221-76196f5b-58af-487c-a728-89b6b18a2f9f.png">

Fix for #717 
