### PR TITLE
fix: fix startup warnings.

### DIFF
--- a/assets/locales/en-US/editor.ftl
+++ b/assets/locales/en-US/editor.ftl
@@ -15,8 +15,6 @@ element-layer-icon = E
 add-element = Add Element
 delete-element = Delete Element
 toggle-visibility = Toggle Visibility
-move-up = Move Up
-move-down = Move Down
 delete-layer = Delete Layer
 delete = Delete
 

--- a/core/src/metadata/element.rs
+++ b/core/src/metadata/element.rs
@@ -254,8 +254,6 @@ pub enum BuiltinElementKind {
         explosion_volume: f32,
         fuse_sound: Handle<AudioSource>,
         fuse_sound_volume: f32,
-        #[serde(skip)]
-        fuse_sound_handle: Handle<AudioSource>,
         /// The time in seconds before a grenade explodes
         fuse_time: f32,
         #[serde(default)]


### PR DESCRIPTION
Remove unused translations and remove unused field from kick bomb.

Fixes: #713 