### PR TITLE
refactor: use bones timer for kick bomb fuse and arm delay.

### DIFF
--- a/assets/elements/item/kick_bomb/kick_bomb.element.yaml
+++ b/assets/elements/item/kick_bomb/kick_bomb.element.yaml
@@ -1,7 +1,7 @@
 name: Kick Bomb
 category: Weapons
 builtin: !KickBomb
-  fuse_time: 8.0
+  fuse_time: 8.0s
   kick_velocity: [10, 6]
   throw_velocity: 10
   damage_region_size: [60, 60]
@@ -26,4 +26,4 @@ builtin: !KickBomb
   bounciness: 0.6
   angular_velocity: 0.1
   # arm_delay: 0.02
-  arm_delay: 0.5
+  arm_delay: 0.5s

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -209,7 +209,7 @@ fn update_lit_kick_bombs(
             unreachable!();
         };
 
-        kick_bomb.arm_delay.tick(time.delta());
+        kick_bomb.fuse_time.tick(time.delta());
 
         let mut should_explode = false;
         // If the item is being held
@@ -259,7 +259,7 @@ fn update_lit_kick_bombs(
             } else if !player_standing_left && player_sprite.flip_x {
                 body.velocity.x = -kick_velocity.x;
                 body.velocity.y = kick_velocity.y;
-            } else if kick_bomb.arm_delay.finished() || kick_bomb.fuse_time.finished() {
+            } else if kick_bomb.fuse_time.finished() {
                 should_explode = true;
             }
         }

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use std::time::Duration;
 
 pub fn install(session: &mut GameSession) {
     session
@@ -147,14 +146,8 @@ fn update_idle_kick_bombs(
                     lit.insert(
                         entity,
                         LitKickBomb {
-                            arm_delay: Timer::new(
-                                arm_delay,
-                                TimerMode::Once,
-                            ),
-                            fuse_time: Timer::new(
-                                fuse_time,
-                                TimerMode::Once,
-                            ),
+                            arm_delay: Timer::new(arm_delay, TimerMode::Once),
+                            fuse_time: Timer::new(fuse_time, TimerMode::Once),
                         },
                     );
                 },

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -210,6 +210,7 @@ fn update_lit_kick_bombs(
         };
 
         kick_bomb.fuse_time.tick(time.delta());
+        kick_bomb.arm_delay.tick(time.delta());
 
         let mut should_explode = false;
         // If the item is being held
@@ -265,7 +266,7 @@ fn update_lit_kick_bombs(
         }
 
         // If it's time to explode
-        if kick_bomb.arm_delay.finished() || kick_bomb.fuse_time.finished() || should_explode {
+        if kick_bomb.fuse_time.finished() || should_explode {
             audio_events.play(explosion_sound.clone(), *explosion_volume);
 
             trauma_events.send(7.5);

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -148,11 +148,11 @@ fn update_idle_kick_bombs(
                         entity,
                         LitKickBomb {
                             arm_delay: Timer::new(
-                                Duration::from_secs_f32(arm_delay.as_secs_f32()),
+                                arm_delay,
                                 TimerMode::Once,
                             ),
                             fuse_time: Timer::new(
-                                Duration::from_secs_f32(fuse_time.as_secs_f32()),
+                                fuse_time,
                                 TimerMode::Once,
                             ),
                         },

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -148,11 +148,11 @@ fn update_idle_kick_bombs(
                         entity,
                         LitKickBomb {
                             arm_delay: Timer::new(
-                                Duration::from_secs_f32(arm_delay),
+                                Duration::from_secs_f32(arm_delay.as_secs_f32()),
                                 TimerMode::Once,
                             ),
                             fuse_time: Timer::new(
-                                Duration::from_secs_f32(fuse_time),
+                                Duration::from_secs_f32(fuse_time.as_secs_f32()),
                                 TimerMode::Once,
                             ),
                         },

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -261,7 +261,7 @@ fn update_lit_kick_bombs(
             } else if !player_standing_left && player_sprite.flip_x {
                 body.velocity.x = -kick_velocity.x;
                 body.velocity.y = kick_velocity.y;
-            } else if kick_bomb.fuse_time.finished() {
+            } else if kick_bomb.arm_delay.finished() {
                 should_explode = true;
             }
         }

--- a/core/src/metadata/element.rs
+++ b/core/src/metadata/element.rs
@@ -255,7 +255,8 @@ pub enum BuiltinElementKind {
         fuse_sound: Handle<AudioSource>,
         fuse_sound_volume: f32,
         /// The time in seconds before a grenade explodes
-        fuse_time: f32,
+        #[serde(with = "humantime_serde")]
+        fuse_time: Duration,
         #[serde(default)]
         can_rotate: bool,
         /// The grenade atlas
@@ -265,8 +266,8 @@ pub enum BuiltinElementKind {
         bounciness: f32,
         #[serde(default)]
         angular_velocity: f32,
-        #[serde(default)]
-        arm_delay: f32,
+        #[serde(with = "humantime_serde")]
+        arm_delay: Duration,
     },
     Musket {
         #[serde(default)]


### PR DESCRIPTION
Added bomb timer to kick_bomb.rs instead of manually setting the time. 

Fixes: #741 