### PR TITLE
fix: fix kick-bomb time parsing in element YAML.

### DIFF
--- a/assets/elements/item/kick_bomb/kick_bomb.element.yaml
+++ b/assets/elements/item/kick_bomb/kick_bomb.element.yaml
@@ -1,7 +1,7 @@
 name: Kick Bomb
 category: Weapons
 builtin: !KickBomb
-  fuse_time: 8.0s
+  fuse_time: 8s
   kick_velocity: [10, 6]
   throw_velocity: 10
   damage_region_size: [60, 60]
@@ -26,4 +26,4 @@ builtin: !KickBomb
   bounciness: 0.6
   angular_velocity: 0.1
   # arm_delay: 0.02
-  arm_delay: 0.5s
+  arm_delay: 500ms


### PR DESCRIPTION
Apparently serde humantime doesn't support floating points.