### PR TITLE
fix: fix crash related to menu music not looping.

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -105,6 +105,7 @@ fn music_system(
                         instance: music
                             .play(song.inner.clone_weak())
                             .linear_fade_in(MUSIC_FADE_DURATION)
+                            .looped()
                             .handle(),
                         idx: 0,
                     };
@@ -122,6 +123,7 @@ fn music_system(
                         music
                             .play(game.music.character_screen.inner.clone_weak())
                             .linear_fade_in(MUSIC_FADE_DURATION)
+                            .looped()
                             .handle(),
                     );
                 }
@@ -136,6 +138,7 @@ fn music_system(
                         music
                             .play(game.music.title_screen.inner.clone_weak())
                             .linear_fade_in(MUSIC_FADE_DURATION)
+                            .looped()
                             .handle(),
                     );
                 }
@@ -150,6 +153,7 @@ fn music_system(
                         music
                             .play(game.music.credits.inner.clone_weak())
                             .linear_fade_in(MUSIC_FADE_DURATION)
+                            .looped()
                             .handle(),
                     );
                 }


### PR DESCRIPTION
The music tracks were not set to play on looped mode for menus such as the character selection or home menu. This would cause the game to crash when the track had finished and the transition to another menu page caused the system to try and stop the currently playing song ( which was no longer playing ).