### PR TITLE
fix: fix 3 and 4 player LAN games.

### DIFF
--- a/src/networking.rs
+++ b/src/networking.rs
@@ -40,6 +40,7 @@ pub static NETWORK_ENDPOINT: Lazy<quinn::Endpoint> = Lazy::new(|| {
 
     // Open Socket and create endpoint
     let port = rand::thread_rng().gen_range(10000..=11000); // Bind a random port
+    info!(port, "Started network endpoint");
     let socket = std::net::UdpSocket::bind(("0.0.0.0", port)).unwrap();
 
     let client_config = rustls::ClientConfig::builder()

--- a/src/ui/main_menu/network_game.rs
+++ b/src/ui/main_menu/network_game.rs
@@ -377,6 +377,7 @@ impl<'w, 's> WidgetSystem for MatchmakingMenu<'w, 's> {
                                         networking::LanMatchmakerResponse::GameStarting {
                                             lan_socket,
                                             player_idx,
+                                            player_count,
                                         } => {
                                             info!(?player_idx, "Starting network game");
                                             let map_meta = params
@@ -411,12 +412,7 @@ impl<'w, 's> WidgetSystem for MatchmakingMenu<'w, 's> {
                                                     player_is_local: std::array::from_fn(|i| {
                                                         i == player_idx
                                                     }),
-                                                    player_count: lan_socket
-                                                        .connections
-                                                        .iter()
-                                                        .filter(|x| x.is_some())
-                                                        .count()
-                                                        + 1,
+                                                    player_count,
                                                     socket: lan_socket,
                                                 },
                                             );
@@ -541,6 +537,7 @@ impl<'w, 's> WidgetSystem for MatchmakingMenu<'w, 's> {
                                         networking::LanMatchmakerResponse::GameStarting {
                                             lan_socket,
                                             player_idx,
+                                            player_count,
                                         } => {
                                             info!(?player_idx, "Starting network game");
                                             let map_meta = params
@@ -575,12 +572,7 @@ impl<'w, 's> WidgetSystem for MatchmakingMenu<'w, 's> {
                                                     player_is_local: std::array::from_fn(|i| {
                                                         i == player_idx
                                                     }),
-                                                    player_count: lan_socket
-                                                        .connections
-                                                        .iter()
-                                                        .filter(|x| x.is_some())
-                                                        .count()
-                                                        + 1,
+                                                    player_count,
                                                     socket: lan_socket,
                                                 },
                                             );


### PR DESCRIPTION
Previously the peers were only connecting to the matchmaker without coordinating to connect to each-other and be able to start the match.

Fixes: #749