### PR TITLE
style: rename and move LAN session runner to prepare for online matchmaking.

### DIFF
--- a/src/networking/lan.rs
+++ b/src/networking/lan.rs
@@ -3,12 +3,8 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use bevy::tasks::IoTaskPool;
 use bytes::Bytes;
 use futures_lite::{future, FutureExt};
-use jumpy_core::input::PlayerControl;
 
-use super::{
-    proto::{DenseMoveDirection, DensePlayerControl},
-    *,
-};
+use super::*;
 
 pub const NETWORK_FRAME_RATE_FACTOR: f32 = 0.75;
 
@@ -276,26 +272,10 @@ pub enum LanMatchmakerResponse {
     },
 }
 
-pub struct LanSessionRunner {
-    pub last_player_input: PlayerControl,
-    pub core: CoreSession,
-    pub session: P2PSession<GgrsConfig>,
-    pub player_is_local: [bool; MAX_PLAYERS],
-    pub delta: f32,
-    pub accumulator: f32,
-}
-
-#[derive(Debug)]
-pub struct LanSessionInfo {
-    pub socket: LanSocket,
-    pub player_is_local: [bool; MAX_PLAYERS],
-    pub player_count: usize,
-}
-
 #[derive(Debug)]
 pub struct LanSocket {
     pub connections: [Option<quinn::Connection>; MAX_PLAYERS],
-    pub message_channel: async_channel::Receiver<(usize, ggrs::Message)>,
+    pub ggrs_message_channel: async_channel::Receiver<(usize, ggrs::Message)>,
 }
 
 impl LanSocket {
@@ -360,7 +340,7 @@ impl LanSocket {
 
         Self {
             connections,
-            message_channel: receiver,
+            ggrs_message_channel: receiver,
         }
     }
 }
@@ -377,206 +357,9 @@ impl ggrs::NonBlockingSocket<usize> for LanSocket {
 
     fn receive_all_messages(&mut self) -> Vec<(usize, ggrs::Message)> {
         let mut messages = Vec::new();
-        while let Ok(message) = self.message_channel.try_recv() {
+        while let Ok(message) = self.ggrs_message_channel.try_recv() {
             messages.push(message);
         }
         messages
-    }
-}
-
-impl LanSessionRunner {
-    pub fn new(mut core: CoreSession, info: LanSessionInfo) -> Self
-    where
-        Self: Sized,
-    {
-        core.time_step = 1.0 / (jumpy_core::FPS * NETWORK_FRAME_RATE_FACTOR);
-        let mut builder = ggrs::SessionBuilder::new()
-            .with_num_players(info.player_count)
-            .with_max_prediction_window(8)
-            .with_input_delay(1)
-            .with_fps((jumpy_core::FPS * NETWORK_FRAME_RATE_FACTOR) as usize)
-            .unwrap();
-
-        for i in 0..info.player_count {
-            if info.player_is_local[i] {
-                builder = builder.add_player(ggrs::PlayerType::Local, i).unwrap();
-            } else {
-                builder = builder.add_player(ggrs::PlayerType::Remote(i), i).unwrap();
-            }
-        }
-
-        let session = builder.start_p2p_session(info.socket).unwrap();
-
-        Self {
-            last_player_input: PlayerControl::default(),
-            core,
-            session,
-            player_is_local: info.player_is_local,
-            accumulator: default(),
-            delta: default(),
-        }
-    }
-}
-
-fn get_dense_input(control: &PlayerControl) -> DensePlayerControl {
-    let mut dense_control = DensePlayerControl::default();
-    dense_control.set_jump_pressed(control.jump_just_pressed);
-    dense_control.set_grab_pressed(control.grab_pressed);
-    dense_control.set_slide_pressed(control.slide_pressed);
-    dense_control.set_shoot_pressed(control.shoot_pressed);
-    dense_control.set_move_direction(DenseMoveDirection(control.move_direction));
-    dense_control
-}
-
-impl crate::session::SessionRunner for LanSessionRunner {
-    fn core_session(&mut self) -> &mut CoreSession {
-        &mut self.core
-    }
-
-    fn restart(&mut self) {
-        self.core.restart()
-    }
-
-    fn set_player_input(&mut self, player_idx: usize, control: PlayerControl) {
-        if !self.player_is_local[player_idx] {
-            return;
-        }
-        self.last_player_input = control;
-    }
-
-    fn advance(&mut self, bevy_world: &mut World) -> Result<(), SessionError> {
-        const STEP: f32 = 1.0 / (jumpy_core::FPS * NETWORK_FRAME_RATE_FACTOR);
-        let delta = self.delta;
-        let local_player_idx = self.network_player_idx().unwrap();
-
-        self.accumulator += delta;
-
-        let mut skip_frames = 0;
-        for event in self.session.events() {
-            match event {
-                ggrs::GGRSEvent::Synchronizing { addr, total, count } => {
-                    info!(player=%addr, %total, progress=%count, "Syncing network player");
-                }
-                ggrs::GGRSEvent::Synchronized { addr } => {
-                    info!(player=%addr, "Syncrhonized network client");
-                }
-                ggrs::GGRSEvent::Disconnected { .. } => return Err(SessionError::Disconnected),
-                ggrs::GGRSEvent::NetworkInterrupted { addr, .. } => {
-                    info!(player=%addr, "Network player interrupted");
-                }
-                ggrs::GGRSEvent::NetworkResumed { addr } => {
-                    info!(player=%addr, "Network player re-connected");
-                }
-                ggrs::GGRSEvent::WaitRecommendation {
-                    skip_frames: skip_count,
-                } => {
-                    info!(
-                        "Skipping {skip_count} frames to give network players a chance to catch up"
-                    );
-                    skip_frames = skip_count
-                }
-                ggrs::GGRSEvent::DesyncDetected {
-                    frame,
-                    local_checksum,
-                    remote_checksum,
-                    addr,
-                } => {
-                    error!(%frame, %local_checksum, %remote_checksum, player=%addr, "Network de-sync detected");
-                }
-            }
-        }
-
-        loop {
-            self.session
-                .add_local_input(local_player_idx, get_dense_input(&self.last_player_input))
-                .unwrap();
-            if self.accumulator >= STEP {
-                self.accumulator -= STEP;
-
-                if skip_frames > 0 {
-                    skip_frames = skip_frames.saturating_sub(1);
-                    continue;
-                }
-
-                match self.session.advance_frame() {
-                    Ok(requests) => {
-                        for request in requests {
-                            match request {
-                                ggrs::GGRSRequest::SaveGameState { cell, frame } => {
-                                    cell.save(frame, Some(self.core.world.clone()), None)
-                                }
-                                ggrs::GGRSRequest::LoadGameState { cell, .. } => {
-                                    let world = cell.load().unwrap_or_default();
-                                    self.core.world = world;
-                                }
-                                ggrs::GGRSRequest::AdvanceFrame {
-                                    inputs: network_inputs,
-                                } => {
-                                    self.core.update_input(|inputs| {
-                                        for (player_idx, (input, _status)) in
-                                            network_inputs.into_iter().enumerate()
-                                        {
-                                            let control = &mut inputs.players[player_idx].control;
-
-                                            let jump_pressed = input.jump_pressed();
-                                            control.jump_just_pressed =
-                                                jump_pressed && !control.jump_pressed;
-                                            control.jump_pressed = jump_pressed;
-
-                                            let grab_pressed = input.grab_pressed();
-                                            control.grab_just_pressed =
-                                                grab_pressed && !control.grab_pressed;
-                                            control.grab_pressed = grab_pressed;
-
-                                            let shoot_pressed = input.shoot_pressed();
-                                            control.shoot_just_pressed =
-                                                shoot_pressed && !control.shoot_pressed;
-                                            control.shoot_pressed = shoot_pressed;
-
-                                            let was_moving =
-                                                control.move_direction.length_squared()
-                                                    > f32::MIN_POSITIVE;
-                                            control.move_direction = input.move_direction().0;
-                                            let is_moving = control.move_direction.length_squared()
-                                                > f32::MIN_POSITIVE;
-                                            control.just_moved = !was_moving && is_moving;
-                                        }
-                                    });
-                                    self.core.advance(bevy_world);
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => match e {
-                        ggrs::GGRSError::NotSynchronized => {
-                            debug!("Waiting for network clients to sync")
-                        }
-                        ggrs::GGRSError::PredictionThreshold => {
-                            warn!("Freezing game while waiting for network to catch-up.")
-                        }
-                        e => error!("Network protocol error: {e}"),
-                    },
-                }
-            } else {
-                break;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn run_criteria(&mut self, time: &Time) -> bevy::ecs::schedule::ShouldRun {
-        self.delta = time.delta_seconds();
-        bevy::ecs::schedule::ShouldRun::Yes
-    }
-
-    fn network_player_idx(&mut self) -> Option<usize> {
-        // We are the first local player
-        for i in 0..MAX_PLAYERS {
-            if self.player_is_local[i] {
-                return Some(i);
-            }
-        }
-        unreachable!();
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -178,9 +178,9 @@ impl<'w, 's> SessionManager<'w, 's> {
     pub fn start_lan(
         &mut self,
         core_info: CoreSessionInfo,
-        lan_info: crate::networking::LanSessionInfo,
+        lan_info: crate::networking::GgrsSessionRunnerInfo,
     ) {
-        let session = Session(Box::new(crate::networking::LanSessionRunner::new(
+        let session = Session(Box::new(crate::networking::GgrsSessionRunner::new(
             CoreSession::new(core_info),
             lan_info,
         )));

--- a/src/ui/main_menu/network_game.rs
+++ b/src/ui/main_menu/network_game.rs
@@ -6,7 +6,7 @@ use std::{
 use bevy::utils::Instant;
 use smallvec::SmallVec;
 
-use crate::networking::{LanSessionInfo, LAN_MATCHMAKER, NETWORK_ENDPOINT};
+use crate::networking::{GgrsSessionRunnerInfo, LAN_MATCHMAKER, NETWORK_ENDPOINT};
 
 use super::*;
 
@@ -408,7 +408,7 @@ impl<'w, 's> WidgetSystem for MatchmakingMenu<'w, 's> {
 
                                             params.session_manager.start_lan(
                                                 core_info,
-                                                LanSessionInfo {
+                                                GgrsSessionRunnerInfo {
                                                     player_is_local: std::array::from_fn(|i| {
                                                         i == player_idx
                                                     }),
@@ -568,7 +568,7 @@ impl<'w, 's> WidgetSystem for MatchmakingMenu<'w, 's> {
 
                                             params.session_manager.start_lan(
                                                 core_info,
-                                                LanSessionInfo {
+                                                GgrsSessionRunnerInfo {
                                                     player_is_local: std::array::from_fn(|i| {
                                                         i == player_idx
                                                     }),


### PR DESCRIPTION
This renames `LanSessionRunner` to `GgrsSessionRunner` and moves it to the `networking` module to prepare for making the `GgrsSessionRunner` agnostic to LAN or online games with a new network socket trait.