### PR TITLE
feat: increase LAN game frame rate.

### DIFF
--- a/src/networking/lan.rs
+++ b/src/networking/lan.rs
@@ -6,7 +6,7 @@ use futures_lite::{future, FutureExt};
 
 use super::*;
 
-pub const NETWORK_FRAME_RATE_FACTOR: f32 = 0.75;
+pub const NETWORK_FRAME_RATE_FACTOR: f32 = 0.9;
 
 /// Channel used to do matchmaking over LAN.
 ///


### PR DESCRIPTION
This greatly improves the experience at the cost of greater bandwidth, which in bad network conditions might make a worse experience. We may have to experiment to find the best value.

This brings the frame rate up from 45 to 54 frames-per-second for LAN games.