### PR TITLE
fix: fish school removed from editor on element deletion

### DIFF
--- a/core/src/editor.rs
+++ b/core/src/editor.rs
@@ -1,5 +1,4 @@
 use crate::impl_system_param;
-use crate::prelude::fish_school::FishSchool;
 use crate::{map::z_depth_for_map_layer, prelude::*};
 
 pub fn install(session: &mut CoreSession) {
@@ -19,7 +18,7 @@ impl_system_param! {
         tile_layers: CompMut<'a, TileLayer>,
         tiles: CompMut<'a, Tile>,
         tile_collisions: CompMut<'a, TileCollisionKind>,
-        fish_school: CompMut<'a, FishSchool>
+        element_kill_callbacks: Comp<'a, ElementKillCallback>
     }
 }
 
@@ -126,10 +125,10 @@ impl<'a> MapManager<'a> {
         transform.translation.y = position.y;
     }
     fn delete_element(&mut self, entity: Entity) {
-        if let Some(fish_school) = self.fish_school.get_mut(entity) {
-            let kill_callback = fish_school.kill_callback.clone();
+        if let Some(element_kill_callback) = self.element_kill_callbacks.get(entity) {
+            let system = element_kill_callback.system.clone();
             self.commands
-                .add(move |world: &World| (kill_callback.lock().unwrap().run)(world).unwrap());
+                .add(move |world: &World| (system.lock().unwrap().run)(world).unwrap());
         } else {
             // this entity does not contain a kill callback
             self.entities.kill(entity);

--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use crate::prelude::*;
 
 pub mod crab;
@@ -35,6 +37,20 @@ pub struct DehydrateOutOfBounds(pub Entity);
 #[derive(Clone, TypeUlid, Deref, DerefMut, Default)]
 #[ulid = "01GP421CHN323T2614F19PA5E9"]
 pub struct ElementHandle(pub Handle<ElementMeta>);
+
+#[derive(Clone, TypeUlid)]
+#[ulid = "01GP584Z9WN5P0RG2A82MV93P1"]
+pub struct ElementKillCallback {
+    pub system: Arc<Mutex<System>>,
+}
+
+impl ElementKillCallback {
+    pub fn new<Args>(system: impl IntoSystem<Args, ()>) -> Self {
+        ElementKillCallback {
+            system: Arc::new(Mutex::new(system.system())),
+        }
+    }
+}
 
 pub fn install(session: &mut CoreSession) {
     session

--- a/core/src/elements/fish_school.rs
+++ b/core/src/elements/fish_school.rs
@@ -1,4 +1,4 @@
-use std::{sync::Mutex, time::Duration};
+use std::time::Duration;
 
 use crate::{prelude::*, random::GlobalRng};
 
@@ -13,7 +13,6 @@ pub fn install(session: &mut CoreSession) {
 #[ulid = "01GTF48H2WEFC3GSED8V7JNN0K"]
 pub struct FishSchool {
     fish: Vec<Entity>,
-    pub kill_callback: Arc<Mutex<System>>,
 }
 
 #[derive(Clone, TypeUlid, Debug)]
@@ -42,6 +41,7 @@ pub fn hydrate(
     mut colliders: CompMut<Collider>,
     mut atlas_sprites: CompMut<AtlasSprite>,
     mut animated_sprites: CompMut<AnimatedSprite>,
+    mut element_kill_callbacks: CompMut<ElementKillCallback>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -146,15 +146,11 @@ pub fn hydrate(
 
                 fish_ents.push(fish_ent);
             }
-            fish_schools.insert(
+            element_kill_callbacks.insert(
                 fish_school_ent,
-                FishSchool {
-                    fish: fish_ents,
-                    kill_callback: Arc::new(Mutex::new(
-                        fish_school_kill_callback(fish_school_ent).system(),
-                    )),
-                },
+                ElementKillCallback::new(fish_school_kill_callback(fish_school_ent)),
             );
+            fish_schools.insert(fish_school_ent, FishSchool { fish: fish_ents });
         }
     }
 }

--- a/core/src/elements/fish_school.rs
+++ b/core/src/elements/fish_school.rs
@@ -9,7 +9,7 @@ pub fn install(session: &mut CoreSession) {
         .add_system_to_stage(CoreStage::PostUpdate, update_fish_schools);
 }
 
-#[derive(Clone, TypeUlid, Debug)]
+#[derive(Default, Clone, TypeUlid, Debug, Deref, DerefMut)]
 #[ulid = "01GTF48H2WEFC3GSED8V7JNN0K"]
 pub struct FishSchool {
     fish: Vec<Entity>,

--- a/core/src/elements/fish_school.rs
+++ b/core/src/elements/fish_school.rs
@@ -315,7 +315,6 @@ pub fn update_fish_schools(
 
 fn fish_school_kill_callback(entity: Entity) -> System {
     (move |mut entities: ResMut<Entities>, mut fish_school: CompMut<FishSchool>| {
-        let mut to_kill: Vec<Entity> = Vec::new();
         fish_school
             .get_mut(entity)
             .unwrap()
@@ -323,13 +322,9 @@ fn fish_school_kill_callback(entity: Entity) -> System {
             .iter()
             .copied()
             .for_each(|fish_entity| {
-                to_kill.push(fish_entity);
+                entities.kill(fish_entity);
             });
-        to_kill.push(entity);
-
-        to_kill.into_iter().for_each(|entity| {
-            entities.kill(entity);
-        });
+        entities.kill(entity);
     })
     .system()
 }


### PR DESCRIPTION
The rendered fish school (and the subsequent fish) will now be removed when the parent element is removed (right-click element and choose "Delete Element").