### PR TITLE
fix: implement kill callback for all rendered elements

### DIFF
--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -1,5 +1,3 @@
-use std::sync::Mutex;
-
 use crate::prelude::*;
 
 pub mod crab;
@@ -37,20 +35,6 @@ pub struct DehydrateOutOfBounds(pub Entity);
 #[derive(Clone, TypeUlid, Deref, DerefMut, Default)]
 #[ulid = "01GP421CHN323T2614F19PA5E9"]
 pub struct ElementHandle(pub Handle<ElementMeta>);
-
-#[derive(Clone, TypeUlid)]
-#[ulid = "01H0AYCRP3QZKBJX6NQMCET8J6"]
-pub struct ElementKillCallback {
-    pub system: Arc<Mutex<System>>,
-}
-
-impl ElementKillCallback {
-    pub fn new<Args>(system: impl IntoSystem<Args, ()>) -> Self {
-        ElementKillCallback {
-            system: Arc::new(Mutex::new(system.system())),
-        }
-    }
-}
 
 #[derive(Clone, TypeUlid)]
 #[ulid = "01H0AQGTZCVZJXPF2KSR73TQTR"]

--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -55,7 +55,7 @@ impl ElementKillCallback {
 #[derive(Clone, TypeUlid)]
 #[ulid = "01H0AQGTZCVZJXPF2KSR73TQTR"]
 pub struct Spawner {
-    pub spawned_elements: Vec<Entity>
+    pub spawned_elements: Vec<Entity>,
 }
 
 impl Spawner {

--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -39,7 +39,7 @@ pub struct DehydrateOutOfBounds(pub Entity);
 pub struct ElementHandle(pub Handle<ElementMeta>);
 
 #[derive(Clone, TypeUlid)]
-#[ulid = "01GP584Z9WN5P0RG2A82MV93P1"]
+#[ulid = "01H0AYCRP3QZKBJX6NQMCET8J6"]
 pub struct ElementKillCallback {
     pub system: Arc<Mutex<System>>,
 }
@@ -49,6 +49,18 @@ impl ElementKillCallback {
         ElementKillCallback {
             system: Arc::new(Mutex::new(system.system())),
         }
+    }
+}
+
+#[derive(Clone, TypeUlid)]
+#[ulid = "01H0AQGTZCVZJXPF2KSR73TQTR"]
+pub struct Spawner {
+    pub spawned_elements: Vec<Entity>
+}
+
+impl Spawner {
+    pub fn new(spawned_elements: Vec<Entity>) -> Self {
+        Spawner { spawned_elements }
     }
 }
 

--- a/core/src/elements/crab.rs
+++ b/core/src/elements/crab.rs
@@ -50,7 +50,7 @@ fn hydrate(
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
     mut animated_sprites: CompMut<AnimatedSprite>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -117,10 +117,7 @@ fn hydrate(
                 },
             );
 
-            spawners.insert(
-                spawner_ent,
-                Spawner::new(vec![entity])
-            );
+            spawners.insert(spawner_ent, Spawner::new(vec![entity]));
         }
     }
 }
@@ -328,4 +325,3 @@ fn finished_playing(
 ) -> Option<bool> {
     (!repeat).then(|| *index == frames.len() - 1 && *timer > 1.0 / fps.max(f32::MIN_POSITIVE))
 }
-

--- a/core/src/elements/crab.rs
+++ b/core/src/elements/crab.rs
@@ -50,16 +50,17 @@ fn hydrate(
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
     mut animated_sprites: CompMut<AnimatedSprite>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner_ent in spawners {
+    for spawner_ent in spawner_entities {
         let transform = *transforms.get(spawner_ent).unwrap();
         let element_handle = element_handles.get(spawner_ent).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -114,6 +115,11 @@ fn hydrate(
                     frames: spawn_frames.iter().cloned().collect(),
                     ..default()
                 },
+            );
+
+            spawners.insert(
+                spawner_ent,
+                Spawner::new(vec![entity])
             );
         }
     }
@@ -322,3 +328,4 @@ fn finished_playing(
 ) -> Option<bool> {
     (!repeat).then(|| *index == frames.len() - 1 && *timer > 1.0 / fps.max(f32::MIN_POSITIVE))
 }
+

--- a/core/src/elements/crate_item.rs
+++ b/core/src/elements/crate_item.rs
@@ -39,18 +39,19 @@ fn hydrate_crates(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner in spawners {
-        let transform = *transforms.get(spawner).unwrap();
-        let element_handle = element_handles.get(spawner).unwrap();
+    for spawner_entity in spawner_entities {
+        let transform = *transforms.get(spawner_entity).unwrap();
+        let element_handle = element_handles.get(spawner_entity).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else{
             continue;
         };
@@ -67,7 +68,7 @@ fn hydrate_crates(
             continue;
         };
 
-        hydrated.insert(spawner, MapElementHydrated);
+        hydrated.insert(spawner_entity, MapElementHydrated);
 
         let entity = entities.create();
         items.insert(entity, Item);
@@ -82,7 +83,7 @@ fn hydrate_crates(
             },
         );
         atlas_sprites.insert(entity, AtlasSprite::new(atlas.clone()));
-        respawn_points.insert(entity, DehydrateOutOfBounds(spawner));
+        respawn_points.insert(entity, DehydrateOutOfBounds(spawner_entity));
         transforms.insert(entity, transform);
         element_handles.insert(entity, element_handle.clone());
         hydrated.insert(entity, MapElementHydrated);
@@ -98,6 +99,10 @@ fn hydrate_crates(
                 bounciness: *bounciness,
                 ..default()
             },
+        );
+        spawners.insert(
+            spawner_entity,
+            Spawner::new(vec![entity])
         );
     }
 }

--- a/core/src/elements/crate_item.rs
+++ b/core/src/elements/crate_item.rs
@@ -39,7 +39,7 @@ fn hydrate_crates(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -100,10 +100,7 @@ fn hydrate_crates(
                 ..default()
             },
         );
-        spawners.insert(
-            spawner_entity,
-            Spawner::new(vec![entity])
-        );
+        spawners.insert(spawner_entity, Spawner::new(vec![entity]));
     }
 }
 

--- a/core/src/elements/grenade.rs
+++ b/core/src/elements/grenade.rs
@@ -36,16 +36,17 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner_ent in spawners {
+    for spawner_ent in spawner_entities {
         let transform = *transforms.get(spawner_ent).unwrap();
         let element_handle = element_handles.get(spawner_ent).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -100,6 +101,10 @@ fn hydrate(
                     gravity: game_meta.physics.gravity,
                     ..default()
                 },
+            );
+            spawners.insert(
+                spawner_ent,
+                Spawner::new(vec![entity])
             );
         }
     }

--- a/core/src/elements/grenade.rs
+++ b/core/src/elements/grenade.rs
@@ -36,7 +36,7 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -102,10 +102,7 @@ fn hydrate(
                     ..default()
                 },
             );
-            spawners.insert(
-                spawner_ent,
-                Spawner::new(vec![entity])
-            );
+            spawners.insert(spawner_ent, Spawner::new(vec![entity]));
         }
     }
 }

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -34,16 +34,17 @@ fn hydrate(
     mut element_handles: CompMut<ElementHandle>,
     mut animated_sprites: CompMut<AnimatedSprite>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner_ent in spawners {
+    for spawner_ent in spawner_entities {
         let transform = *transforms.get(spawner_ent).unwrap();
         let element_handle = element_handles.get(spawner_ent).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -98,6 +99,10 @@ fn hydrate(
                     bounciness: *bounciness,
                     ..default()
                 },
+            );
+            spawners.insert(
+                spawner_ent,
+                Spawner::new(vec![entity])
             );
         }
     }

--- a/core/src/elements/kick_bomb.rs
+++ b/core/src/elements/kick_bomb.rs
@@ -34,7 +34,7 @@ fn hydrate(
     mut element_handles: CompMut<ElementHandle>,
     mut animated_sprites: CompMut<AnimatedSprite>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -100,10 +100,7 @@ fn hydrate(
                     ..default()
                 },
             );
-            spawners.insert(
-                spawner_ent,
-                Spawner::new(vec![entity])
-            );
+            spawners.insert(spawner_ent, Spawner::new(vec![entity]));
         }
     }
 }

--- a/core/src/elements/mine.rs
+++ b/core/src/elements/mine.rs
@@ -35,7 +35,7 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -93,10 +93,7 @@ fn hydrate(
                     ..default()
                 },
             );
-            spawners.insert(
-                spawner_ent,
-                Spawner::new(vec![entity])
-            );
+            spawners.insert(spawner_ent, Spawner::new(vec![entity]));
         }
     }
 }

--- a/core/src/elements/mine.rs
+++ b/core/src/elements/mine.rs
@@ -35,16 +35,17 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner_ent in spawners {
+    for spawner_ent in spawner_entities {
         let transform = *transforms.get(spawner_ent).unwrap();
         let element_handle = element_handles.get(spawner_ent).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -91,6 +92,10 @@ fn hydrate(
                     gravity: game_meta.physics.gravity,
                     ..default()
                 },
+            );
+            spawners.insert(
+                spawner_ent,
+                Spawner::new(vec![entity])
             );
         }
     }

--- a/core/src/elements/musket.rs
+++ b/core/src/elements/musket.rs
@@ -30,16 +30,17 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner_ent in spawners {
+    for spawner_ent in spawner_entities {
         let transform = *transforms.get(spawner_ent).unwrap();
         let element_handle = element_handles.get(spawner_ent).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -100,6 +101,10 @@ fn hydrate(
                     gravity: game_meta.physics.gravity,
                     ..default()
                 },
+            );
+            spawners.insert(
+                spawner_ent,
+                Spawner::new(vec![entity])
             );
         }
     }

--- a/core/src/elements/musket.rs
+++ b/core/src/elements/musket.rs
@@ -30,7 +30,7 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -102,10 +102,7 @@ fn hydrate(
                     ..default()
                 },
             );
-            spawners.insert(
-                spawner_ent,
-                Spawner::new(vec![entity])
-            );
+            spawners.insert(spawner_ent, Spawner::new(vec![entity]));
         }
     }
 }

--- a/core/src/elements/snail.rs
+++ b/core/src/elements/snail.rs
@@ -33,16 +33,17 @@ fn hydrate(
     mut animation_banks: CompMut<AnimationBankSprite>,
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner_ent in spawners {
+    for spawner_ent in spawner_entities {
         let transform = *transforms.get(spawner_ent).unwrap();
         let element_handle = element_handles.get(spawner_ent).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -113,6 +114,10 @@ fn hydrate(
                     animations: Arc::new(animations),
                     last_animation: key!("hide"),
                 },
+            );
+            spawners.insert(
+                spawner_ent,
+                Spawner::new(vec![entity])
             );
         }
     }

--- a/core/src/elements/snail.rs
+++ b/core/src/elements/snail.rs
@@ -33,7 +33,7 @@ fn hydrate(
     mut animation_banks: CompMut<AnimationBankSprite>,
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -115,10 +115,7 @@ fn hydrate(
                     last_animation: key!("hide"),
                 },
             );
-            spawners.insert(
-                spawner_ent,
-                Spawner::new(vec![entity])
-            );
+            spawners.insert(spawner_ent, Spawner::new(vec![entity]));
         }
     }
 }

--- a/core/src/elements/stomp_boots.rs
+++ b/core/src/elements/stomp_boots.rs
@@ -32,16 +32,17 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner_ent in spawners {
+    for spawner_ent in spawner_entities {
         let transform = *transforms.get(spawner_ent).unwrap();
         let element_handle = element_handles.get(spawner_ent).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -83,6 +84,10 @@ fn hydrate(
                     gravity: game_meta.physics.gravity,
                     ..default()
                 },
+            );
+            spawners.insert(
+                spawner_ent,
+                Spawner::new(vec![entity])
             );
         }
     }

--- a/core/src/elements/stomp_boots.rs
+++ b/core/src/elements/stomp_boots.rs
@@ -32,7 +32,7 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -85,10 +85,7 @@ fn hydrate(
                     ..default()
                 },
             );
-            spawners.insert(
-                spawner_ent,
-                Spawner::new(vec![entity])
-            );
+            spawners.insert(spawner_ent, Spawner::new(vec![entity]));
         }
     }
 }

--- a/core/src/elements/sword.rs
+++ b/core/src/elements/sword.rs
@@ -40,16 +40,17 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner_ent in spawners {
+    for spawner_ent in spawner_entities {
         let transform = *transforms.get(spawner_ent).unwrap();
         let element_handle = element_handles.get(spawner_ent).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -103,6 +104,10 @@ fn hydrate(
                     gravity: game_meta.physics.gravity,
                     ..default()
                 },
+            );
+            spawners.insert(
+                spawner_ent,
+                Spawner::new(vec![entity])
             );
         }
     }

--- a/core/src/elements/sword.rs
+++ b/core/src/elements/sword.rs
@@ -40,7 +40,7 @@ fn hydrate(
     mut item_throws: CompMut<ItemThrow>,
     mut item_grabs: CompMut<ItemGrab>,
     mut respawn_points: CompMut<DehydrateOutOfBounds>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -105,10 +105,7 @@ fn hydrate(
                     ..default()
                 },
             );
-            spawners.insert(
-                spawner_ent,
-                Spawner::new(vec![entity])
-            );
+            spawners.insert(spawner_ent, Spawner::new(vec![entity]));
         }
     }
 }

--- a/core/src/elements/urchin.rs
+++ b/core/src/elements/urchin.rs
@@ -21,7 +21,7 @@ fn hydrate(
     mut sprites: CompMut<Sprite>,
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
-    mut spawners: CompMut<Spawner>
+    mut spawners: CompMut<Spawner>,
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
@@ -76,10 +76,7 @@ fn hydrate(
                     ..default()
                 },
             );
-            spawners.insert(
-                spawner_ent,
-                Spawner::new(vec![entity])
-            );
+            spawners.insert(spawner_ent, Spawner::new(vec![entity]));
         }
     }
 }

--- a/core/src/elements/urchin.rs
+++ b/core/src/elements/urchin.rs
@@ -21,16 +21,17 @@ fn hydrate(
     mut sprites: CompMut<Sprite>,
     mut bodies: CompMut<KinematicBody>,
     mut transforms: CompMut<Transform>,
+    mut spawners: CompMut<Spawner>
 ) {
     let mut not_hydrated_bitset = hydrated.bitset().clone();
     not_hydrated_bitset.bit_not();
     not_hydrated_bitset.bit_and(element_handles.bitset());
 
-    let spawners = entities
+    let spawner_entities = entities
         .iter_with_bitset(&not_hydrated_bitset)
         .collect::<Vec<_>>();
 
-    for spawner_ent in spawners {
+    for spawner_ent in spawner_entities {
         let transform = *transforms.get(spawner_ent).unwrap();
         let element_handle = element_handles.get(spawner_ent).unwrap();
         let Some(element_meta) = element_assets.get(&element_handle.get_bevy_handle()) else {
@@ -74,6 +75,10 @@ fn hydrate(
                     bounciness: *bounciness,
                     ..default()
                 },
+            );
+            spawners.insert(
+                spawner_ent,
+                Spawner::new(vec![entity])
             );
         }
     }


### PR DESCRIPTION
All elements that act as a spawner (except for the fish school since the spawner acts as the parent element holding the inner fish elements) now have a Spawner component that will be discovered during the "delete element" process.
I also updated the ElementKillCallback ulid string since I just created it manually in the previous ticket and only recently learned of a way to generate a true random ulid string.
We should consider refactoring the fish school spawner to properly behave like a spawner containing entities.