### PR TITLE
Fix player spawner kill

### DIFF
--- a/core/src/editor.rs
+++ b/core/src/editor.rs
@@ -133,17 +133,15 @@ impl<'a> MapManager<'a> {
         } else {
             if let Some(spawner) = self.spawners.get(entity) {
                 // search for other spawners in the same group
-                let is_last_spawner_from_group = self
+                let grouped_spawners_count = self
                     .spawners
                     .iter()
                     .filter(|other_spawner| {
                         spawner.group_identifier == other_spawner.group_identifier
                     })
-                    .peekable()
-                    .peek()
-                    .is_some();
+                    .count();
 
-                if is_last_spawner_from_group {
+                if grouped_spawners_count == 1 {
                     spawner.spawned_elements.iter().copied().for_each(|entity| {
                         // TODO recursively search for nested spawners
 

--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -65,10 +65,16 @@ pub struct Spawner {
 
 impl Spawner {
     pub fn new(spawned_elements: Vec<Entity>) -> Self {
-        Spawner { spawned_elements, group_identifier: Uuid::new_v4().to_string() }
+        Spawner {
+            spawned_elements,
+            group_identifier: Uuid::new_v4().to_string(),
+        }
     }
     pub fn new_grouped(spawned_elements: Vec<Entity>, group_identifier: String) -> Self {
-        Spawner { spawned_elements, group_identifier }
+        Spawner {
+            spawned_elements,
+            group_identifier,
+        }
     }
 }
 

--- a/core/src/elements.rs
+++ b/core/src/elements.rs
@@ -1,3 +1,7 @@
+use std::sync::Mutex;
+
+use ::bevy::utils::Uuid;
+
 use crate::prelude::*;
 
 pub mod crab;
@@ -37,14 +41,34 @@ pub struct DehydrateOutOfBounds(pub Entity);
 pub struct ElementHandle(pub Handle<ElementMeta>);
 
 #[derive(Clone, TypeUlid)]
+#[ulid = "01GP584Z9WN5P0RG2A82MV93P1"]
+pub struct ElementKillCallback {
+    pub system: Arc<Mutex<System>>,
+}
+
+impl ElementKillCallback {
+    pub fn new<Args>(system: impl IntoSystem<Args, ()>) -> Self {
+        ElementKillCallback {
+            system: Arc::new(Mutex::new(system.system())),
+        }
+    }
+}
+
+#[derive(Clone, TypeUlid)]
 #[ulid = "01H0AQGTZCVZJXPF2KSR73TQTR"]
 pub struct Spawner {
+    /// The spawned elements that should be killed when this spawner is killed
     pub spawned_elements: Vec<Entity>,
+    /// The group identifier where all of the elements are meant to be shared between them
+    pub group_identifier: String,
 }
 
 impl Spawner {
     pub fn new(spawned_elements: Vec<Entity>) -> Self {
-        Spawner { spawned_elements }
+        Spawner { spawned_elements, group_identifier: Uuid::new_v4().to_string() }
+    }
+    pub fn new_grouped(spawned_elements: Vec<Entity>, group_identifier: String) -> Self {
+        Spawner { spawned_elements, group_identifier }
     }
 }
 

--- a/core/src/elements/player_spawner.rs
+++ b/core/src/elements/player_spawner.rs
@@ -40,15 +40,16 @@ fn hydrate(
             player_spawners.insert(entity, PlayerSpawner);
 
             // try to find one other spawner and store the existing player entities
-            if let Some((_, (_, first_spawner))) = entities
-                .iter_with((&player_spawners, &spawners))
-                .next() {
-
+            if let Some((_, (_, first_spawner))) =
+                entities.iter_with((&player_spawners, &spawners)).next()
+            {
                 // all of the player spawners share the same group identifier
-                let spawner = Spawner::new_grouped(first_spawner.spawned_elements.clone(), first_spawner.group_identifier.clone());
+                let spawner = Spawner::new_grouped(
+                    first_spawner.spawned_elements.clone(),
+                    first_spawner.group_identifier.clone(),
+                );
                 spawners.insert(entity, spawner);
-            }
-            else {
+            } else {
                 let spawner = Spawner::new(vec![]);
                 spawners.insert(entity, spawner);
             }
@@ -118,7 +119,9 @@ fn update(
 }
 
 fn player_kill_callback(player_entity: Entity) -> System {
-    (move |mut entities: ResMut<Entities>, attachments: Comp<Attachment>, player_layers: Comp<PlayerLayers>| {
+    (move |mut entities: ResMut<Entities>,
+           attachments: Comp<Attachment>,
+           player_layers: Comp<PlayerLayers>| {
         entities
             .iter_with(&attachments)
             .filter(|(_, attachment)| attachment.entity == player_entity)

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1,6 +1,11 @@
 use std::collections::VecDeque;
 
-use crate::{item::ItemGrabbed, physics::KinematicBody, prelude::{*, player_spawner::PlayerSpawner}, random::GlobalRng};
+use crate::{
+    item::ItemGrabbed,
+    physics::KinematicBody,
+    prelude::{player_spawner::PlayerSpawner, *},
+    random::GlobalRng,
+};
 
 mod state;
 use bones_lib::animation::AnimationBankSprite;
@@ -168,7 +173,7 @@ impl PlayerCommand {
                player_indexes: Comp<PlayerIdx>,
                player_layers: Comp<PlayerLayers>,
                player_spawners: Comp<PlayerSpawner>,
-               mut spawners: CompMut<Spawner>,| {
+               mut spawners: CompMut<Spawner>| {
             if player_indexes.contains(player) {
                 entities
                     .iter_with(&attachments)


### PR DESCRIPTION
The player spawners can now be removed and the last player spawner to be removed will also remove the rendered players. This is done because the players are able to spawn from a single player spawner (if that is the only spawner), so removing the rendered players after removing all but the last spawner would simply cause them to respawn from the existing player spawner(s).

The ElementKillCallback needed to be brought back into the system in order to facilitate the complex killing of the rendered player entities.