### PR TITLE
refactor: moved SettingsTab to settings.rs

### DIFF
--- a/src/ui/main_menu.rs
+++ b/src/ui/main_menu.rs
@@ -15,7 +15,7 @@ use crate::{
     ui::ui_input::MenuAction,
 };
 
-use self::settings::{ModifiedSettings, SettingsTab};
+use self::settings::ModifiedSettings;
 
 use super::{
     widget,
@@ -149,14 +149,6 @@ impl Default for MenuPage {
     fn default() -> Self {
         Self::Home
     }
-}
-
-impl SettingsTab {
-    const TABS: &'static [(Self, &'static str)] = &[
-        (Self::Controls, "controls"),
-        (Self::Networking, "networking"), // For now, hide the sound tab because we don't have it working yet.
-                                          // (Self::Sound, "sound")
-    ];
 }
 
 /// Render the main menu UI

--- a/src/ui/main_menu/settings.rs
+++ b/src/ui/main_menu/settings.rs
@@ -16,6 +16,14 @@ pub enum SettingsTab {
     Networking,
 }
 
+impl SettingsTab {
+    const TABS: &'static [(Self, &'static str)] = &[
+        (Self::Controls, "controls"),
+        (Self::Networking, "networking"), // For now, hide the sound tab because we don't have it working yet.
+                                          // (Self::Sound, "sound")
+    ];
+}
+
 impl Default for SettingsTab {
     fn default() -> Self {
         Self::Controls


### PR DESCRIPTION
Moves the code for the `SettingsTab` struct to the settings.rs file, where the struct itself is.
Hopefully resolves #778.