### PR TITLE
build: remove transitive bevy_pbr dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,6 @@ dependencies = [
  "bevy_hierarchy",
  "bevy_log",
  "bevy_math",
- "bevy_pbr",
  "bevy_reflect",
  "bevy_render",
  "bevy_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ debug-network-slowdown = ["async-timer", "turborand"]
 anyhow                 = "1.0.58"
 async-channel          = "1.7.1"
 base64                 = "0.21.0"
-bevy-inspector-egui    = { version = "0.17.0" }
+bevy-inspector-egui    = { version = "0.17.0", default-features = false }
 bevy_egui              = "0.19.0"
 bevy_fluent            = "0.5.0"
 bevy_framepace         = "0.11.0"


### PR DESCRIPTION
closes #614 

Removes transitive bevy_pbr dependency as found with help of `cargo tree -i bevy_pbr `. 