### PR TITLE
fix: make AI less effective so they are more fun to play against.

### DIFF
--- a/core/src/player/state/states/walk.rs
+++ b/core/src/player/state/states/walk.rs
@@ -81,9 +81,15 @@ pub fn handle_player_state(
         // Walk in movement direction
         body.velocity.x += meta.stats.accel_walk_speed * control.move_direction.x;
         if control.move_direction.x.is_sign_positive() {
-            body.velocity.x = body.velocity.x.min(meta.stats.walk_speed);
+            body.velocity.x = body
+                .velocity
+                .x
+                .min(meta.stats.walk_speed * control.move_direction.x);
         } else {
-            body.velocity.x = body.velocity.x.max(-meta.stats.walk_speed);
+            body.velocity.x = body
+                .velocity
+                .x
+                .max(meta.stats.walk_speed * control.move_direction.x);
         }
 
         // Point in movement direction


### PR DESCRIPTION
- Adds random pauses to AI movement.
- Slows AI movement down.
- Makes AI get closer to player before swinging sword.
- Also allows players to move slower by tilting the stick less.

Resolves #787