### PR TITLE
chore(release): add ARM64 linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
       matrix:
         config:
           - { os: ubuntu-latest, target: "x86_64-unknown-linux-gnu" }
+          - { os: ubuntu-latest, target: "aarch64-unknown-linux-gnu" }
           - { os: macos-latest, target: "x86_64-apple-darwin" }
           - { os: macos-latest, target: "aarch64-apple-darwin" }
           - { os: windows-latest, target: "x86_64-pc-windows-msvc" }
@@ -71,14 +72,6 @@ jobs:
       - name: ⬇️ Checkout
         uses: actions/checkout@v3
 
-      - name: 🧰 Install dependencies
-        if: matrix.config.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y -q \
-              libasound2-dev \
-              libudev-dev
-
       - name: 🦀 Setup Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -92,6 +85,7 @@ jobs:
         with:
           command: build
           args: --release --locked --target ${{ matrix.config.target }}
+          use-cross: true
 
       - name: ⚙️ Prepare artifacts [Windows]
         shell: bash

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,11 @@
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install -y pkg-config libasound2-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH",
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install -y pkg-config libasound2-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH",
+]


### PR DESCRIPTION
Closes #788

Tested here: https://github.com/orhun/FishFight/actions/runs/5204576645 

Unfortunately, `cross` doesn't support wildcard for targets so there is a bit of code duplication in the config. See https://github.com/cross-rs/cross/issues/1244