### PR TITLE
fix: input controls being applied to ai players.

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -266,7 +266,7 @@ fn collect_local_input(
     }
 
     for (player_idx, action_state) in &player_input_collectors {
-        if network_player_idx.is_some() && player_idx.0 != 0 {
+        if player_idx.0 != 0 {
             continue;
         }
 


### PR DESCRIPTION
fixes #722 

I'm still getting familiar with the code, but it looks like what's happening is that when you press the Grab/Drop key on Keyboard 2, the input sometimes makes the AI player drop the sword and when it has enough velocity it gets insta-killed by collision detection (this I think is related to #714). I was able to reproduce this issue in a local game only.

After some digging, I found that this seems to be caused the session's input being propagated to all the player inputs including the AIs in a local session (when `network_player_idx.is_some()`). Removing the condition skips the loop for AI players locally and still works in a network game, where each local player has `player_idx = 0`.