### PR TITLE
docs: add more Jumpy API documentation.

### DIFF
--- a/docs/rustdoc-mermaid-head.html
+++ b/docs/rustdoc-mermaid-head.html
@@ -59,11 +59,20 @@
     }
 </script>
 <style>
+    /*
+        Hide the lock icons shown for private items. It isn't helpful
+        in this context.
+    */
+    [title="Restricted Visibility"] {
+        display: none;
+    }
+
     .mermaid {
         overflow: hidden !important;
         border: 1px solid #BBB;
         border-radius: 1em;
-        cursor: move
+        cursor: move;
+        position: relative;
     }
 
     .dotted rect {

--- a/src/README.md
+++ b/src/README.md
@@ -12,16 +12,23 @@ Jumpy is still under heavy development and the docs as well as the code will be 
 incomplete. If you want to help out, feel free to fill in some missing docs or clarify something we
 didn't explain very well. We're glad to answer any questions you might have along the way!
 
-#### Organization
+### Organization
 
-Each of the modules in the list below contains it's own docs, which should explain details of what
-is contained in that model and how it works. Some of these may be simple, and others, such as the
+The [`main()`] function is the first function called in the game. It creates the Bevy [`App`], installs our plugins, and starts the game.
+
+All of the game logic is wrapped up in Bevy plugins. There is very often a plugin for each of the
+top-level modules. The names of our custom plugins are prefixed with `Jumpy` so that they can be
+easily recognized from 3rd party plugins that we also install. For example, we have the
+[`JumpyUiPlugin`] and the [`JumpySessionPlugin`] which reside in the [`ui`] and [`session`] modules
+respectively.
+
+Each of the modules contains it's own docs. Some of these may be simple, and others, such as the
 [`networking`] module have guide-level explanations on that facet of the game.
 
 Feel free to explore whatever seems interesting to you, and please [open an issue][gh_issue] if you
 feel like something is missing, or would like further guidance on a particular topic!
 
-##### Diagrams
+#### Diagrams
 
 Throughout the docs there are diagrams to explain certain topics. These may contain clickable links, highlighted in blue, that will bring you to the relevant module or struct. We also use a convention to indicate what kind of code object it links to, based on the shape of the box.
 
@@ -41,7 +48,7 @@ You can pan the diagram by clicking and dragging or zoom by holding `ctrl` and s
 
 There are a few major crates that are used in Jumpy:
 
-- [Jumpy Core][jumpy_core] - Core Gameplay Logic
+- [Jumpy Core][::jumpy_core] - Core Gameplay Logic
 - [Bones](https://fishfolk.org/development/bones/introduction/) - Core Entity Component System & Rendering Components
 - [Bevy](https://bevyengine.org) - Rendering, Asset Loading, and User Input
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,3 +1,5 @@
+//! Custom asset loaders and handle types.
+
 use bevy::{
     asset::{AssetLoader, LoadedAsset},
     reflect::TypeUuid,
@@ -7,9 +9,11 @@ use bones_bevy_asset::BonesBevyAssetAppExt;
 
 use crate::{metadata::GameMeta, prelude::*};
 
+#[doc(hidden)]
 mod asset_handle;
 pub use asset_handle::AssetHandle;
 
+/// Asset plugin.
 pub struct JumpyAssetPlugin;
 
 impl Plugin for JumpyAssetPlugin {
@@ -20,10 +24,12 @@ impl Plugin for JumpyAssetPlugin {
     }
 }
 
+/// Asset type containing [`egui::FontData`][crate::external::egui::FontData].
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "421c9e38-89be-43ff-a293-6fea65abf946"]
 pub struct EguiFont(pub egui::FontData);
 
+/// Bevy asset loader for [`EguiFont`] assets.
 pub struct EguiFontLoader;
 
 impl AssetLoader for EguiFontLoader {

--- a/src/assets/asset_handle.rs
+++ b/src/assets/asset_handle.rs
@@ -9,7 +9,8 @@ use normalize_path::NormalizePath;
 
 use crate::prelude::*;
 
-/// A wrapper around [`Handle<T>`] that also contains the [`AssetPath`] used to load the asset.
+/// A wrapper around [`Handle<T>`] that also contains the
+/// [`AssetPath`][crate::external::bevy::asset::AssetPath] used to load the asset.
 ///
 /// Unlike [`Handle<T>`], this type is serializable and deserializable and can be sent over the
 /// network.

--- a/src/bevy_states.rs
+++ b/src/bevy_states.rs
@@ -1,0 +1,49 @@
+//! Bevy [`States`] used in the game.
+//!
+//! We have three different Bevy state types. The [`EngineState`] is the "parent" or "main" state.
+//! We take advantage of the ability to have multiple different kinds of states in Bevy and have
+//! [`InGameState`] and [`GameEditorState`] represent the game pause state and editor visibility
+//! when the [`EngineState`] is set to [`EngineState::InGame`].
+
+use crate::prelude::*;
+
+/// Bevy [`States`] related to the top-level state of the game.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, States, Default)]
+pub enum EngineState {
+    /// The initial state: the game is loading it's platform-specific [`Storage`].
+    #[default]
+    LoadingPlatformStorage,
+    /// The game is in the process of loading assets and processing the metadata.
+    ///
+    /// See also: [`load_game()`][loading::GameLoader::load].
+    LoadingGameData,
+    /// The game is on the main menu.
+    ///
+    /// This includes other sub-menus such as player/map selection, and settings menus, etc.
+    MainMenu,
+    /// There is a game match being played.
+    ///
+    /// This includes when you are editing a map, which has a game match going during editing.
+    InGame,
+}
+
+/// Bevy [`States`] that are relevant while the [`EngineState::InGame`] state is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, States, Default)]
+pub enum InGameState {
+    /// The game match is playing.
+    #[default]
+    Playing,
+    /// The game is paused.
+    Paused,
+}
+
+/// Bevy [`States`] tracking the editor visibility, relevant only while the [`EngineState::InGame`]
+/// state is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, States, Default)]
+pub enum GameEditorState {
+    /// The editor is hidden.
+    #[default]
+    Hidden,
+    /// The editor is visible.
+    Visible,
+}

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,15 +1,26 @@
+//! Utilities for the menu camera.
+//!
+//! The in-game camera is not dealt with here because it will created and managed automatically by
+//! [`bones_bevy_renderer`].
+//!
+//! [`bones_bevy_renderer`]: https://docs.rs/bones_bevy_renderer
+
 use bevy::render::camera::ScalingMode;
 
 use crate::prelude::*;
 
+/// Marker component added to the camera that is used to render the main menu.
 #[derive(Reflect, Component, Default)]
 #[reflect(Component, Default)]
 pub struct MenuCamera;
 
+/// Helper function to spawn the menu camera.
+///
+/// Called in [`loading::GameLoader::load()`].
 pub fn spawn_menu_camera(commands: &mut Commands, core: &CoreMeta) -> Entity {
     commands
         .spawn((
-            Name::new("Game Camera"),
+            Name::new("Menu Camera"),
             MenuCamera,
             Camera2dBundle {
                 // Note: This is different than just omitting this transform field because

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,23 @@
+//! Jumpy startup configuration parsing.
+//!
+//! The [`EngineConfig`] contains the minimal configuration necessary when starting up the game
+//! initially. This includes the asset dir and the log level.
+//!
+//! [`EngineConfig`] is parsed from commandline arguments or environment variables on native
+//! platforms, and from the query string on web.
+
 use once_cell::sync::Lazy;
 
-pub const SERVER_MODE_ENV_VAR: &str = "JUMPY_SERVER_MODE";
+/// The name of the environment variable used to set the asset dir.
 pub const ASSET_DIR_ENV_VAR: &str = "JUMPY_ASSET_DIR";
 
+/// The default log level string.
 const DEFAULT_LOG_LEVEL: &str = "info,wgpu=error,bevy_fluent=warn,symphonia_core=warn,symphonia_format_ogg=warn,symphonia_bundle_mp3=warn";
 
+/// The loaded engine config is stored in this static.
+///
+/// It is a lazy static, but the first thing that [`main()`][crate::main()] does is load it so it
+/// will be loaded for the duration of the game's execution.
 pub static ENGINE_CONFIG: Lazy<EngineConfig> = Lazy::new(|| {
     #[cfg(not(target_arch = "wasm32"))]
     return <EngineConfig as clap::Parser>::parse();
@@ -13,6 +26,7 @@ pub static ENGINE_CONFIG: Lazy<EngineConfig> = Lazy::new(|| {
     return EngineConfig::from_web_params();
 });
 
+/// Jumpy game startup configuration.
 #[derive(Clone, Debug, clap::Parser)]
 #[command(author, version, about)]
 pub struct EngineConfig {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use crate::{
-    assets::*, audio::*, camera::*, config::*, debug::*, input::*, loading::*, localization::*,
-    metadata::*, platform::*, session::*, ui::*, utils::*, *,
+    assets::*, audio::*, bevy_states::*, camera::*, config::*, debug::*, input::*, loading::*,
+    localization::*, metadata::*, platform::*, session::*, ui::*, utils::*, *,
 };
 pub use anyhow::Context;
 pub use jumpy_core::bevy_prelude::*;

--- a/src/session.rs
+++ b/src/session.rs
@@ -321,7 +321,7 @@ fn update_game(world: &mut World) {
 }
 
 /// Play sounds from the game session.
-fn play_sounds(audio: Res<AudioChannel<EffectsChannel>>, mut session: ResMut<Session>) {
+pub fn play_sounds(audio: Res<AudioChannel<EffectsChannel>>, mut session: ResMut<Session>) {
     // Get the sound queue out of the world
     let queue = session
         .world()


### PR DESCRIPTION
- improved main page and several modules.
- also move state enums into their own module for readability.

Works on: #479