### PR TITLE
fix: fix debug tools window checkbox for profile window.

### DIFF
--- a/assets/locales/en-US/debug-tools.ftl
+++ b/assets/locales/en-US/debug-tools.ftl
@@ -1,11 +1,11 @@
 debug-tools = Debug Tools
-show-kinematic-colliders = Show Kinematic Colliders
-show-damage-regions = Show Damage Regions
-show-world-inspector = Show World Inspector
-show-frame-time-diagnostics = Show Frame Time Diagnostics
-show-network-visualizer = Show Network Visualizer
-show-profiler = Show Profiler
-show-pathfinding-lines = Show Pathfinding Lines
+kinematic-colliders = Kinematic Colliders
+damage-regions = Damage Regions
+world-inspector = World Inspector
+frame-time-diagnostics = Frame Time Diagnostics
+network-visualizer = Network Visualizer
+profiler = Profiler
+pathfinding-lines = Pathfinding Lines
 
 profiler = Profiler
 

--- a/src/ui/debug_tools.rs
+++ b/src/ui/debug_tools.rs
@@ -94,36 +94,40 @@ fn debug_tools_window(
         .id(egui::Id::new("debug_tools"))
         .open(&mut visible)
         .show(egui_ctxs.ctx_mut(), |ui| {
+            ui.heading("Render");
+
             // Show collision shapes
             ui.checkbox(
                 &mut core_debug_settings.show_kinematic_colliders,
-                format!("{} ( F10 )", localization.get("show-kinematic-colliders")),
+                format!("{} ( F10 )", localization.get("kinematic-colliders")),
             );
             ui.checkbox(
                 &mut core_debug_settings.show_damage_regions,
-                format!("{} ( F10 )", localization.get("show-damage-regions")),
+                format!("{} ( F10 )", localization.get("damage-regions")),
             );
             ui.checkbox(
                 &mut core_debug_settings.show_pathfinding_lines,
-                localization.get("show-pathfinding-lines"),
+                localization.get("pathfinding-lines"),
             );
+
+            ui.heading("Windows");
 
             // Show world inspector
             ui.checkbox(
                 &mut show_inspector.0,
-                format!("{} ( F9 )", localization.get("show-world-inspector")),
+                format!("{} ( F9 )", localization.get("world-inspector")),
             );
 
             // Show frame time diagnostics
             ui.checkbox(
                 &mut show_debug_windows.frame_time_diagnostics,
-                format!("{} ( F8 )", localization.get("show-frame-time-diagnostics")),
+                format!("{} ( F8 )", localization.get("frame-time-diagnostics")),
             );
 
             // Show profiler
             ui.checkbox(
-                &mut show_debug_windows.frame_time_diagnostics,
-                format!("{} ( F7 )", localization.get("show-profiler")),
+                &mut show_debug_windows.profiler,
+                format!("{} ( F7 )", localization.get("profiler")),
             );
 
             // Snapshot/Restore buttons
@@ -245,7 +249,7 @@ fn profiler_window(
     localization: Res<Localization>,
     mut egui_ctx: EguiContexts,
 ) {
-    puffin::set_scopes_on(show.profiler);
+    puffin::set_scopes_on(true);
     if show.profiler {
         egui::Window::new(&localization.get("profiler"))
             .id(egui::Id::new("profiler"))


### PR DESCRIPTION
This fixes the way that the profile window check box was toggling the frame-time diagnostics, instead of the profiler window.

Also improves organization of the window by adding a couple headings for the different kinds of toggles.