### PR TITLE
fix:  Fix puffin profiler not showing anything

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,7 +2894,7 @@ dependencies = [
  "peg",
  "ping-rs",
  "postcard",
- "puffin 0.15.0",
+ "puffin",
  "puffin_egui",
  "quinn",
  "quinn_runtime_bevy",
@@ -2928,7 +2928,7 @@ dependencies = [
  "nalgebra",
  "ordered-float",
  "petgraph",
- "puffin 0.16.0",
+ "puffin",
  "rapier2d",
  "serde",
  "shiftnanigans",
@@ -4027,19 +4027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "puffin"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76425abd4e1a0ad4bd6995dd974b52f414fca9974171df8e3708b3e660d05a21"
-dependencies = [
- "anyhow",
- "byteorder",
- "cfg-if",
- "instant",
- "once_cell",
-]
-
-[[package]]
 name = "puffin_egui"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4050,7 +4037,7 @@ dependencies = [
  "instant",
  "natord",
  "once_cell",
- "puffin 0.15.0",
+ "puffin",
  "time",
  "vec1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,7 +2894,7 @@ dependencies = [
  "peg",
  "ping-rs",
  "postcard",
- "puffin 0.16.0",
+ "puffin 0.15.0",
  "puffin_egui",
  "quinn",
  "quinn_runtime_bevy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4018,6 +4018,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "instant",
+ "js-sys",
  "once_cell",
  "parking_lot 0.12.1",
  "ruzstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log                    = { version = "0.4", features = ["release_max_level_debug
 normalize-path         = "0.2"
 once_cell              = "1.17"
 peg                    = "0.8"
-puffin                 = "0.16"
+puffin                 = "0.15"
 puffin_egui            = "0.21"
 rand                   = "0.8"
 serde                  = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log                    = { version = "0.4", features = ["release_max_level_debug
 normalize-path         = "0.2"
 once_cell              = "1.17"
 peg                    = "0.8"
-puffin                 = "0.15"
+puffin                 = { version = "0.15", features = ["web"] }
 puffin_egui            = "0.21"
 rand                   = "0.8"
 serde                  = { version = "1.0", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ indexmap        = "1.9"
 nalgebra        = { version = "0.32", features = ["convert-glam023"] }
 ordered-float   = "3.4"
 petgraph        = { version = "0.6", features = ["graphmap"], default-features = false }
-puffin          = "0.16"
+puffin          = { version = "0.15", features = ["web"] }
 rapier2d        = { version = "0.17", features = ["enhanced-determinism", "debug-render"] }
 serde           = { version = "1.0", features = ["derive"] }
 tracing         = "0.1"


### PR DESCRIPTION
Fix #831, we are using incompatible puffin / puffin-egui versions.

We updated puffin to 0.16, but did not upgrade puffin_egui to 0.22 (these versions were bumped together). We likely did not upgrade puffin_egui because this causes a compilation error, as bevy_egui is still using dep egui 0.21 (while puffin_egui is at 0.22), types mismatch.

Downgrading puffin to 0.15 fixes it. Can upgrade puffin crates once bevy_egui has a release with egui 0.22.


Additionally, fixes a panic opening profiler in wasm due to missing web feature.