### PR TITLE
fix: change /bin/env to /usr/bin/env in build-web.sh.

### DIFF
--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #
 # This script is usually run by the justfile


### PR DESCRIPTION
/bin/env does not exist on the system I am currently using (macOS 12.5). 

It seems to me /bin/usr/env is probably more common - that said I really hope this change wouldn't create the opposite problem for others. (Though could always do #!/bin/bash). 

Probably worth addressing one way or another so script does not require local modification to build wasm.