### PR TITLE
feat(profiling): allow puffin to capture tracing spans for profiling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_utils",
  "console_error_panic_hook",
+ "tracing-error",
  "tracing-log",
  "tracing-subscriber",
  "tracing-wasm",
@@ -927,6 +928,7 @@ dependencies = [
  "naga",
  "once_cell",
  "parking_lot 0.12.1",
+ "profiling",
  "regex",
  "serde",
  "smallvec",
@@ -2582,15 +2584,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -2761,7 +2754,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2772,7 +2765,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.48.0",
@@ -2927,6 +2920,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tracing",
+ "tracing-core",
  "tracing-log",
  "tracing-subscriber",
  "tracing-wasm",
@@ -3515,11 +3509,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4061,6 +4055,20 @@ name = "profiling"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
+dependencies = [
+ "profiling-procmacros",
+ "tracing",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10adb8d151bb1280afb8bed41ae5db26be1b056964947133c7525b0bf39c0b0"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "puffin"
@@ -5143,6 +5151,16 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = [".", "core"]
 default = []
 # Enable to simulate horrible network latency/slowness
 debug-network-slowdown = ["async-timer", "turborand"]
+# Enable bevy tracing scopes in profiling
+profiling-full= ["bevy/trace"]
 
 [dependencies]
 bones_bevy_asset    = "0.2"
@@ -55,6 +57,7 @@ serde                  = { version = "1.0", features = ["derive"] }
 serde_yaml             = "0.9"
 thiserror              = "1.0"
 tracing                = { version = "0.1", features = ["release_max_level_debug"] }
+tracing-core           = "0.1"
 tracing-log            = "0.1"
 tracing-subscriber     = "0.3"
 unic-langid            = "0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ pub mod localization;
 pub mod logs;
 pub mod metadata;
 pub mod platform;
+pub mod puffin_tracing;
 pub mod session;
 pub mod ui;
 pub mod utils;

--- a/src/puffin_tracing.rs
+++ b/src/puffin_tracing.rs
@@ -1,0 +1,202 @@
+///! This is based the work done here: https://github.com/bevyengine/bevy/pull/4730
+///! This creates puffin scopes from tracing - integrating bevy's profiling traces with puffin.
+use puffin::ThreadProfiler;
+use std::{cell::RefCell, collections::VecDeque};
+use tracing_core::{
+    span::{Attributes, Id, Record},
+    Field, Subscriber,
+};
+use tracing_subscriber::{
+    field::MakeVisitor,
+    fmt::{
+        format::{DefaultFields, Writer},
+        FormatFields, FormattedFields,
+    },
+    layer::Context,
+    registry::LookupSpan,
+    Layer,
+};
+
+/// Format puffin scope such that field 'name' is displayed as
+/// its value instead of field debug formatting (like name="{value}")
+#[derive(Default, Debug)]
+pub struct PuffinScopeFormatter;
+
+/// Visitor implementing formatting for [`PuffinScopeFormatter`]
+pub struct PuffinScopeVisitor<'a> {
+    writer: Writer<'a>,
+    is_empty: bool,
+    result: Result<(), std::fmt::Error>,
+}
+
+impl<'a> PuffinScopeVisitor<'a> {
+    pub fn new(writer: Writer<'a>, is_empty: bool) -> Self {
+        Self {
+            writer,
+            is_empty,
+            result: Ok(()),
+        }
+    }
+
+    fn maybe_pad(&mut self) {
+        if self.is_empty {
+            self.is_empty = false;
+        } else {
+            self.result = write!(self.writer, " ");
+        }
+    }
+}
+
+impl<'a> tracing_subscriber::field::Visit for PuffinScopeVisitor<'a> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if self.result.is_err() {
+            return;
+        }
+
+        if field.name() == "name" {
+            self.record_debug(field, &format_args!("{value}"))
+        } else {
+            // If fields other than 'name' included in span, debug print.
+            self.record_debug(field, &value)
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, value: &dyn std::fmt::Debug) {
+        if self.result.is_err() {
+            return;
+        }
+        self.maybe_pad();
+        self.result = write!(self.writer, "{value:?}");
+    }
+}
+
+impl<'a> tracing_subscriber::field::VisitOutput<std::fmt::Result> for PuffinScopeVisitor<'a> {
+    fn finish(self) -> std::fmt::Result {
+        self.result
+    }
+}
+
+impl<'a> tracing_subscriber::field::VisitFmt for PuffinScopeVisitor<'a> {
+    fn writer(&mut self) -> &mut dyn std::fmt::Write {
+        &mut self.writer
+    }
+}
+
+impl<'a> MakeVisitor<Writer<'a>> for PuffinScopeFormatter {
+    type Visitor = PuffinScopeVisitor<'a>;
+
+    #[inline]
+    fn make_visitor(&self, target: Writer<'a>) -> Self::Visitor {
+        PuffinScopeVisitor::new(target, true)
+    }
+}
+
+thread_local! {
+    static PUFFIN_SPAN_STACK: RefCell<VecDeque<(Id, usize)>> =
+        RefCell::new(VecDeque::with_capacity(16));
+}
+
+/// A tracing layer that collects data for puffin.
+pub struct PuffinLayer<F = DefaultFields> {
+    fmt: F,
+}
+
+impl Default for PuffinLayer<DefaultFields> {
+    fn default() -> Self {
+        Self {
+            fmt: DefaultFields::default(),
+        }
+    }
+}
+
+impl PuffinLayer<DefaultFields> {
+    /// Create a new `PuffinLayer`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Use a custom field formatting implementation.
+    pub fn with_formatter<F>(self, fmt: F) -> PuffinLayer<F> {
+        let _ = self;
+        PuffinLayer { fmt }
+    }
+}
+
+impl<S, F> Layer<S> for PuffinLayer<F>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    F: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        if !puffin::are_scopes_on() {
+            return;
+        }
+
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if extensions.get_mut::<FormattedFields<F>>().is_none() {
+                let mut fields = FormattedFields::<F>::new(String::with_capacity(64));
+                if self.fmt.format_fields(fields.as_writer(), attrs).is_ok() {
+                    extensions.insert(fields);
+                }
+            }
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if let Some(fields) = extensions.get_mut::<FormattedFields<F>>() {
+                let _ = self.fmt.add_fields(fields, values);
+            } else {
+                let mut fields = FormattedFields::<F>::new(String::with_capacity(64));
+                if self.fmt.format_fields(fields.as_writer(), values).is_ok() {
+                    extensions.insert(fields);
+                }
+            }
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        if !puffin::are_scopes_on() {
+            return;
+        }
+
+        if let Some(span_data) = ctx.span(id) {
+            let metadata = span_data.metadata();
+            let name = metadata.name();
+            let target = metadata.target();
+            let extensions = span_data.extensions();
+            let data = extensions
+                .get::<FormattedFields<F>>()
+                .map(|fields| fields.fields.as_str())
+                .unwrap_or_default();
+
+            ThreadProfiler::call(|tp| {
+                let start_stream_offset = tp.begin_scope(name, target, data);
+                PUFFIN_SPAN_STACK.with(|s| {
+                    s.borrow_mut().push_back((id.clone(), start_stream_offset));
+                });
+            });
+        }
+    }
+
+    fn on_exit(&self, id: &Id, _ctx: Context<'_, S>) {
+        PUFFIN_SPAN_STACK.with(|s| {
+            let value = s.borrow_mut().pop_back();
+            if let Some((last_id, start_stream_offset)) = value {
+                if *id == last_id {
+                    ThreadProfiler::call(|tp| tp.end_scope(start_stream_offset));
+                } else {
+                    s.borrow_mut().push_back((last_id, start_stream_offset));
+                }
+            }
+        });
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(&id) {
+            span.extensions_mut().remove::<FormattedFields<F>>();
+        }
+    }
+}


### PR DESCRIPTION
Adds feature flag "profiling-full" to jumpy that allows profiling bevy in puffin. (https://github.com/fishfolk/jumpy/issues/837)

Bevy profiling is implemented with tracing spans, this change adds a layer creating puffin scopes from spans, based off of work from here: https://github.com/mvlabat/bevy_puffin. Includes some custom field formatting so we don't get debug formatting in puffin scopes, the default was a bit hard to read.

This is behind a feature flag as it requires enabling tracing in bevy, which causes significant performance issues in wasm. The profile scopes are a bit harder to sift through as there is a lot more information, however it should be helpful for getting a more detailed understanding of what is happening. 

Example screenshot below, hard to get all the interesting stuff on the screen at once, but there is more stuff on other threads displayed, like rendering tasks for example.
<img width="1512" alt="image" src="https://github.com/fishfolk/jumpy/assets/35712032/6c5ea21d-083e-4f93-9062-93fdb28213b7">


