### PR TITLE
fix: fixes occasional crash in loading while accessing hats.

### DIFF
--- a/src/loading.rs
+++ b/src/loading.rs
@@ -46,6 +46,7 @@ fn core_assets_loaded(
     core_assets: Res<Assets<CoreMeta>>,
     player_assets: Res<Assets<PlayerMeta>>,
     atlas_assets: Res<Assets<TextureAtlas>>,
+    hat_assets: Res<Assets<HatMeta>>,
 ) -> bool {
     // The game asset
     let Some(game) = game_assets.get(&game_handle) else {
@@ -92,6 +93,16 @@ fn core_assets_loaded(
     for tileset_handle in &core.map_tilesets {
         if atlas_assets
             .get(&tileset_handle.get_bevy_handle_untyped().typed())
+            .is_none()
+        {
+            return false;
+        }
+    }
+
+    // Hats
+    for hats_handle in &core.player_hats {
+        if hat_assets
+            .get(&hats_handle.get_bevy_handle_untyped().typed())
             .is_none()
         {
             return false;


### PR DESCRIPTION
Maybe I should've opened a bug for this (still can if we want one), but I think I identified the issue.

I've crashed  a handful of times in loading.rs, (GameLoader), here:
```rust
        // Load player hat atlase egui handles
        for hat_handle in &core.player_hats {
            let hat_meta = self.hat_assets.get(&hat_handle.get_bevy_handle()).unwrap();
            let path = hat_meta.atlas.path.clone()
```

I believe this is because we were not waiting for asset to be loaded (checking if the hat asset had been loading in core_assets_loaded), so some of the time if not yet loaded by bevy would fail to get asset.