### PR TITLE
refactor(profiling): support Tracy profiler for tracing spans. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,6 +2336,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,6 +2936,7 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "tracing-tracy",
  "tracing-wasm",
  "turborand",
  "type_ulid",
@@ -3101,6 +3115,19 @@ name = "log"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+
+[[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lyon_algorithms"
@@ -4535,6 +4562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+
+[[package]]
 name = "ruzstd"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4577,6 +4610,12 @@ checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -5193,6 +5232,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tracy"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c48ef3e655220d4e43a6be44aa84f078c3004357251cab45f9cc15551a593e"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
 name = "tracing-wasm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5201,6 +5251,26 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d99f5fc382239d08b6bf05bb6206a585bfdb988c878f2499081d0f285ef7819"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ members = [".", "core"]
 default = []
 # Enable to simulate horrible network latency/slowness
 debug-network-slowdown = ["async-timer", "turborand"]
-# Enable bevy tracing scopes in profiling
-profiling-full= ["bevy/trace"]
+# Enable bevy tracing scopes in profiling and tracy profiler support.
+profiling-full= ["bevy/trace", "dep:tracing-tracy"]
 
 [dependencies]
 bones_bevy_asset    = "0.2"
@@ -72,6 +72,12 @@ version  = "0.10"
 default-features = false
 features         = ["x11", "png", "filesystem_watcher", "bevy_gilrs"]
 version          = "0.10"
+
+[dependencies.tracing-tracy]
+version = "0.10.0"
+default-features = false
+features = ["enable", "system-tracing", "context-switch-tracing", "code-transfer"]
+optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.83"

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -20,7 +20,12 @@ impl Plugin for JumpyDebugPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<WorldInspectorEnabled>()
             .add_system(world_inspector)
-            .add_system((|| puffin::GlobalProfiler::lock().new_frame()).in_base_set(CoreSet::Last));
+            .add_system(
+                (|| {
+                    profiling::mark_new_frame();
+                })
+                .in_base_set(CoreSet::Last),
+            );
 
         let type_registry = app.world.resource::<bevy::app::AppTypeRegistry>();
         let mut type_registry = type_registry.write();

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ pub mod localization;
 pub mod logs;
 pub mod metadata;
 pub mod platform;
+pub mod profiling;
 pub mod puffin_tracing;
 pub mod session;
 pub mod ui;

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -1,0 +1,90 @@
+use tracing_core::Field;
+use tracing_subscriber::{field::MakeVisitor, fmt::format::Writer};
+
+/// Format scope such that field 'name' is displayed as
+/// its value instead of field debug formatting (like name="{value}")
+#[derive(Default, Debug)]
+pub struct ProfilingScopeFormatter;
+
+/// Visitor implementing formatting for [`ProfilingScopeFormatter`]
+pub struct ProfilingScopeVisitor<'a> {
+    writer: Writer<'a>,
+    is_empty: bool,
+    result: Result<(), std::fmt::Error>,
+}
+
+impl<'a> ProfilingScopeVisitor<'a> {
+    pub fn new(writer: Writer<'a>, is_empty: bool) -> Self {
+        Self {
+            writer,
+            is_empty,
+            result: Ok(()),
+        }
+    }
+
+    fn maybe_pad(&mut self) {
+        if self.is_empty {
+            self.is_empty = false;
+        } else {
+            self.result = write!(self.writer, " ");
+        }
+    }
+}
+
+impl<'a> tracing_subscriber::field::Visit for ProfilingScopeVisitor<'a> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if self.result.is_err() {
+            return;
+        }
+
+        if field.name() == "name" {
+            self.record_debug(field, &format_args!("{value}"))
+        } else {
+            // If fields other than 'name' included in span, debug print.
+            self.record_debug(field, &value)
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, value: &dyn std::fmt::Debug) {
+        if self.result.is_err() {
+            return;
+        }
+        self.maybe_pad();
+        self.result = write!(self.writer, "{value:?}");
+    }
+}
+
+impl<'a> tracing_subscriber::field::VisitOutput<std::fmt::Result> for ProfilingScopeVisitor<'a> {
+    fn finish(self) -> std::fmt::Result {
+        self.result
+    }
+}
+
+impl<'a> tracing_subscriber::field::VisitFmt for ProfilingScopeVisitor<'a> {
+    fn writer(&mut self) -> &mut dyn std::fmt::Write {
+        &mut self.writer
+    }
+}
+
+impl<'a> MakeVisitor<Writer<'a>> for ProfilingScopeFormatter {
+    type Visitor = ProfilingScopeVisitor<'a>;
+
+    #[inline]
+    fn make_visitor(&self, target: Writer<'a>) -> Self::Visitor {
+        ProfilingScopeVisitor::new(target, true)
+    }
+}
+
+/// Notify profilers we are at frame boundary
+pub fn mark_new_frame() {
+    // Tell puffin we are on new frame
+    puffin::GlobalProfiler::lock().new_frame();
+
+    #[cfg(feature = "profiling-full")]
+    // tell tracy we are on new frame
+    tracing::event!(
+        tracing::Level::INFO,
+        message = "finished frame",
+        tracy.frame_mark = true
+    );
+}


### PR DESCRIPTION
Renamed PuffinScopeFormatter to ProfilingScopeFormatter, moved into profiling.rs. Enables support for Tracy under profiling-full feature.

Shouldn't impact puffin at all, just opening PR as I have been enjoying tracy and wanted to make the work available for others.