### PR TITLE
feat(network-debug): Network debug tool shows ggrs network stats per player

### DIFF
--- a/assets/locales/en-US/debug-tools.ftl
+++ b/assets/locales/en-US/debug-tools.ftl
@@ -27,6 +27,7 @@ confirmed-frame = Confirmed Frame
 delta = Delta
 predicted-frames = Predicted Frames
 predicted = predicted
+player = Player
 
 snapshot = Snapshot
 take-snapshot = Take Snapshot


### PR DESCRIPTION
GGRS has api exposing network stats per remote player, this change collects this data and displays in network debug tool.

This shows current ping, send queue length, estimated frames ahead/behind this player is from local player, and kb/s being sent.

<img width="456" alt="image" src="https://github.com/fishfolk/jumpy/assets/35712032/ce90e66d-cf18-4b37-9b1a-283170d9021b">
