### PR TITLE
feat: Skip update_kinematic_bodies shove loop and check falling branch if object has not moved since last update.

### DIFF
--- a/core/src/physics.rs
+++ b/core/src/physics.rs
@@ -80,6 +80,12 @@ pub struct KinematicBody {
     /// This is important to make sure that it falls through JumpThrough platforms if it happens to
     /// spawn inside of one.
     pub is_spawning: bool,
+
+    /// Position cached from last kinematic body update, used to determine if object is "sleeping"
+    /// (is not moving) to avoid collision detection / resolution against static objects.
+    pub last_update_position: Vec2,
+    /// See comment for `last_update_position`, this tracks previous rotation to detect if object has moved.
+    pub last_update_rotation: f32,
 }
 
 impl KinematicBody {
@@ -149,7 +155,15 @@ fn update_kinematic_bodies(
             collision_world.colliders.get_mut(entity).unwrap().disabled = false;
         }
 
-        if body.has_mass {
+        // has the body moved since last call to update_kinematic_bodies?
+        let has_moved = {
+            let transform = transforms.get(entity).copied().unwrap();
+            let rotation = transform.rotation.to_euler(EulerRot::XYZ).2;
+            body.last_update_position != transform.translation.xy()
+                || body.last_update_rotation != rotation
+                || body.is_spawning // Don't consider new objects
+        };
+        if body.has_mass && has_moved {
             puffin::profile_scope!("Shove objects out of walls");
 
             // Shove objects out of walls
@@ -314,6 +328,10 @@ fn update_kinematic_bodies(
                 body.shape,
             );
         }
+
+        let transform = transforms.get_mut(entity).unwrap();
+        body.last_update_position = transform.translation.xy();
+        body.last_update_rotation = transform.rotation.to_euler(EulerRot::XYZ).2;
     }
 }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -577,6 +577,7 @@ fn hydrate_players(
                 has_mass: true,
                 has_friction: false,
                 gravity: meta.gravity,
+                is_controlled: true,
                 ..default()
             },
         );


### PR DESCRIPTION
So the stat shown in #847 wasn't too representative of the costs as I had removed the critters and such.

This change checks if kinematic has moved since last update, and only tries shove out if it has moved. (If hasn't moved, either isn't colliding and doesn't need shove out, or is stuck and another shove out will yield same results and remain stuck).

This removed about 1ms from update_kinematic_bodies.
<img width="881" alt="image" src="https://github.com/fishfolk/jumpy/assets/35712032/6cd42b75-f9e2-4eb8-b166-97043953a4f5">


Would like to leave #847 open, I am aiming to also skip the fallthrough collision check if hasn't moved, however there is additional complexity here related to fall_through bool, and I don't want to break stuff so that will come later. If we can skip that - should be able to get this function to almost only spend time on moving objects and save even more.