### PR TITLE
fix(prediction): Increase max prediction window to 10.

### DIFF
--- a/src/networking.rs
+++ b/src/networking.rs
@@ -23,7 +23,7 @@ pub const NETWORK_FRAME_RATE_FACTOR: f32 = 0.9;
 
 /// Number of frames client may predict beyond confirmed frame before freezing and waiting
 /// for inputs from other players.
-pub const NETWORK_MAX_PREDICTION_WINDOW: usize = 8;
+pub const NETWORK_MAX_PREDICTION_WINDOW: usize = 10;
 
 /// The [`ggrs::Config`] implementation used by Jumpy.
 #[derive(Debug)]


### PR DESCRIPTION
increase max prediction window to 10, seems to remove freezes due to latency in my testing, we can proceed to tune further once we have data points. Concern is rollbacks max-cost may increase, in practice I have not hit rewinds above 8 frames anyway.