### PR TITLE
fix(character_movement): Fix sleeping kinematic / has_moved optimization causing AI to sink into ground

### DIFF
--- a/src/core/physics.rs
+++ b/src/core/physics.rs
@@ -173,6 +173,11 @@ fn update_kinematic_bodies(
                 || body.last_update_rotation != rotation
                 || body.is_spawning // Don't consider new objects
         };
+
+        let transform = transforms.get_mut(entity).unwrap();
+        body.last_update_position = transform.translation.xy();
+        body.last_update_rotation = transform.rotation.to_euler(EulerRot::XYZ).2;
+
         if body.has_mass && has_moved {
             puffin::profile_scope!("Shove objects out of walls");
 
@@ -344,10 +349,6 @@ fn update_kinematic_bodies(
                 body.shape,
             );
         }
-
-        let transform = transforms.get_mut(entity).unwrap();
-        body.last_update_position = transform.translation.xy();
-        body.last_update_rotation = transform.rotation.to_euler(EulerRot::XYZ).2;
     }
 }
 


### PR DESCRIPTION
I seem to have set the update of saved positions used to determine if kinematic has moved in the wrong spot, ended up in a situation in which AI thinks it had not moved, but was inching down by -0.1 each frame, sinking into ground.

I was able to repro fairly consistently and feeling pretty confident this should fix the AI sinking into ground described in #882. (Though I do not believe this is related to the losing control of player bit).

EDIT:  #853 (objects stuck in walls) also appears to be resolved by this fix.

