### PR TITLE
chore: update Cargo.lock to include correct crate version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "jumpy"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "async-channel",
  "bevy_dylib",


### PR DESCRIPTION
This was accidentally missed from the latest commit.