### PR TITLE
chore(release): bump crate version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ dependencies = [
 
 [[package]]
 name = "jumpy"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "async-channel",
  "bevy_dylib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "A tactical 2D shooter"
 edition     = "2021"
 license     = "MIT OR Apache-2.0"
 name        = "jumpy"
-version     = "0.9.3"
+version     = "0.9.4"
 
 [features]
 default = []


### PR DESCRIPTION
The previous release had not included the update to the Cargo.lock, so this makes another release to fix that.