### PR TITLE
feat: Add a find helper method to `PlayerInventories`

### DIFF
--- a/src/core/elements/crate_item.rs
+++ b/src/core/elements/crate_item.rs
@@ -154,12 +154,8 @@ fn update_idle_crates(
 
         let break_timeout = *break_timeout;
 
-        if let Some(Inv { player, .. }) = player_inventories
-            .iter()
-            .find_map(|x| x.filter(|x| x.inventory == entity))
-        {
-            if items_used.get(entity).is_some() {
-                items_used.remove(entity);
+        if let Some(Inv { player, .. }) = player_inventories.find_item(entity) {
+            if items_used.remove(entity).is_some() {
                 commands.add(PlayerCommand::set_inventory(player, None));
                 commands.add(
                     move |mut idle: CompMut<IdleCrate>, mut thrown: CompMut<ThrownCrate>| {

--- a/src/core/elements/grenade.rs
+++ b/src/core/elements/grenade.rs
@@ -252,10 +252,7 @@ fn update_lit_grenades(
         let emote_region = emote_regions.get_mut(entity).unwrap();
 
         // If the item is being held
-        if let Some(inventory) = player_inventories
-            .iter()
-            .find_map(|x| x.filter(|x| x.inventory == entity))
-        {
+        if let Some(inventory) = player_inventories.find_item(entity) {
             let player = inventory.player;
             let layers = player_layers.get_mut(player).unwrap();
             layers.fin_anim = *fin_anim;

--- a/src/core/elements/jellyfish.rs
+++ b/src/core/elements/jellyfish.rs
@@ -159,20 +159,16 @@ fn update_unused_jellyfish(
             jellyfish.ammo -= 1;
 
             // Get the owner of the jellyfish, if any
-            let Some(owner) = player_inventories
-                .iter()
-                .find_map(|inv| inv.filter(|i| i.inventory == jellyfish_ent))
-                .map(|inv| inv.player)
-            else {
+            let Some(Inv { player, .. }) = player_inventories.find_item(jellyfish_ent) else {
                 continue;
             };
 
             // Prevent the jellyfish from being used if the owner isn't idle
-            if player_states.get(owner).map(|s| s.current) != Some(*idle::ID) {
+            if player_states.get(player).map(|s| s.current) != Some(*idle::ID) {
                 continue;
             }
 
-            commands.add(flappy_jellyfish::spawn(owner, jellyfish_ent));
+            commands.add(flappy_jellyfish::spawn(player, jellyfish_ent));
         }
     }
 }

--- a/src/core/elements/kick_bomb.rs
+++ b/src/core/elements/kick_bomb.rs
@@ -164,9 +164,8 @@ fn update_idle_kick_bombs(
         let arm_delay = *arm_delay;
         let fuse_time = *fuse_time;
 
-        if items_used.get(entity).is_some() {
+        if items_used.remove(entity).is_some() {
             audio_events.play(*fuse_sound, *fuse_sound_volume);
-            items_used.remove(entity);
             let animated_sprite = animated_sprites.get_mut(entity).unwrap();
             animated_sprite.frames = [3, 4, 5].into_iter().collect();
             animated_sprite.repeat = true;
@@ -237,11 +236,7 @@ fn update_lit_kick_bombs(
 
         let mut should_explode = false;
         // If the item is being held
-        if let Some(inventory) = player_inventories
-            .iter()
-            .find_map(|x| x.filter(|x| x.inventory == entity))
-        {
-            let player = inventory.player;
+        if let Some(Inv { player, .. }) = player_inventories.find_item(entity) {
             let body = bodies.get_mut(entity).unwrap();
             player_layers.get_mut(player).unwrap().fin_anim = *fin_anim;
 

--- a/src/core/elements/mine.rs
+++ b/src/core/elements/mine.rs
@@ -147,12 +147,8 @@ fn update_idle_mines(
         };
         let arm_delay = *arm_delay;
 
-        if let Some(Inv { player, .. }) = player_inventories
-            .iter()
-            .find_map(|x| x.filter(|x| x.inventory == entity))
-        {
-            if items_used.get(entity).is_some() {
-                items_used.remove(entity);
+        if let Some(Inv { player, .. }) = player_inventories.find_item(entity) {
+            if items_used.remove(entity).is_some() {
                 commands.add(PlayerCommand::set_inventory(player, None));
                 commands.add(
                     move |mut idle: CompMut<IdleMine>, mut thrown: CompMut<ThrownMine>| {

--- a/src/core/elements/musket.rs
+++ b/src/core/elements/musket.rs
@@ -180,17 +180,9 @@ fn update(
         musket.cooldown.tick(time.delta());
 
         // If the item is being held
-        if let Some(inventory) = player_inventories
-            .iter()
-            .find_map(|x| x.filter(|x| x.inventory == entity))
-        {
-            let player = inventory.player;
-
+        if let Some(Inv { player, .. }) = player_inventories.find_item(entity) {
             // If the item is being used
-            let item_used = items_used.get(entity).is_some();
-            if item_used {
-                items_used.remove(entity);
-            }
+            let item_used = items_used.remove(entity).is_some();
             if item_used && musket.cooldown.finished() {
                 // Empty
                 if musket.ammo.eq(&0) {

--- a/src/core/elements/stomp_boots.rs
+++ b/src/core/elements/stomp_boots.rs
@@ -128,10 +128,7 @@ fn update(
         };
 
         // If the item is being held
-        if let Some(Inv { player, .. }) = player_inventories
-            .iter()
-            .find_map(|x| x.filter(|x| x.inventory == entity))
-        {
+        if let Some(Inv { player, .. }) = player_inventories.find_item(entity) {
             // If the item is being used
             let is_item_used = items_used.get(entity).is_some();
             let player_decoration = *player_decoration;

--- a/src/core/elements/sword.rs
+++ b/src/core/elements/sword.rs
@@ -198,11 +198,7 @@ fn update(
         };
 
         // If the item is being held
-        if let Some(inventory) = player_inventories
-            .iter()
-            .find_map(|x| x.filter(|x| x.inventory == entity))
-        {
-            let player = inventory.player;
+        if let Some(Inv { player, .. }) = player_inventories.find_item(entity) {
             let sprite = sprites.get_mut(entity).unwrap();
             let player_translation = transforms.get(player).unwrap().translation;
             let flip = sprite.flip_x;
@@ -289,14 +285,11 @@ fn update(
             }
 
             // If the item is being used
-            let item_used = items_used.get(entity).is_some();
-            if item_used {
-                items_used.remove(entity);
-                if matches!(sword.state, SwordState::Idle) {
-                    sprite.index = 8;
-                    sword.state = SwordState::Swinging { frame: 0 };
-                    audio_events.play(*sound, *sound_volume);
-                }
+            let item_used = items_used.remove(entity).is_some();
+            if item_used && matches!(sword.state, SwordState::Idle) {
+                sprite.index = 8;
+                sword.state = SwordState::Swinging { frame: 0 };
+                audio_events.play(*sound, *sound_volume);
             }
         } else {
             let body = bodies.get(entity).unwrap();

--- a/src/core/player.rs
+++ b/src/core/player.rs
@@ -955,27 +955,23 @@ fn equip_hats(
 ) {
     for (hat_ent, hat) in entities.iter_with(&hats) {
         // If the hat is being held
-        if let Some(inventory) = player_inventories
-            .iter()
-            .find_map(|x| x.filter(|x| x.inventory == hat_ent))
-        {
-            if items_used.contains(hat_ent) {
-                items_used.remove(hat_ent).unwrap();
-                inventories.get_mut(inventory.player).unwrap().0 = None;
+        if let Some(Inv { player, .. }) = player_inventories.find_item(hat_ent) {
+            if items_used.remove(hat_ent).is_some() {
+                inventories.get_mut(player).unwrap().0 = None;
 
                 let hat_meta = assets.get(hat.0);
                 kinematic_bodies.get_mut(hat_ent).unwrap().is_deactivated = true;
                 player_body_attachments.insert(
                     hat_ent,
                     PlayerBodyAttachment {
-                        player: inventory.player,
+                        player,
                         offset: hat_meta.offset.extend(PlayerLayers::HAT_Z_OFFSET),
                         head: true,
                         sync_animation: false,
                         sync_color: true,
                     },
                 );
-                player_layers.get_mut(inventory.player).unwrap().hat_ent = Some(hat_ent);
+                player_layers.get_mut(player).unwrap().hat_ent = Some(hat_ent);
             }
         }
     }

--- a/src/core/player/state/states/drive_jellyfish.rs
+++ b/src/core/player/state/states/drive_jellyfish.rs
@@ -28,8 +28,7 @@ pub fn player_state_transition(
             }
         } else {
             let Some(player_state) = player_inventories
-                .iter()
-                .find_map(|inv| inv.filter(|i| i.inventory == jellyfish_ent))
+                .find_item(jellyfish_ent)
                 .and_then(|inventory| player_states.get_mut(inventory.player))
             else {
                 continue;


### PR DESCRIPTION
I noticed that in many places in the codebase, it's necessary to find the inventory that contains some item (usually to get the player entity), if any exists, from the `PlayerInventories` system param. This simply adds a helper method `find_item` that does the `.iter().find_map(...)` that is duplicated in many places.

There is also some minor cleanup regarding `ComponentStore::remove`.