### PR TITLE
feat: Jellyfish v2

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -31,8 +31,8 @@ use crate::{prelude::*, settings::PlayerControlMapping};
 pub mod prelude {
     pub use super::{
         attachment::*, audio::*, bullet::*, camera::*, damage::*, debug::*, editor::*, editor::*,
-        elements::prelude::*, globals::*, input::*, item::*, lifetime::*, map::*,
-        map_constructor::*, metadata::*, physics::*, player::*, random::*, utils::*, FPS,
+        elements::prelude::*, flappy_jellyfish::*, globals::*, input::*, item::*, lifetime::*,
+        map::*, map_constructor::*, metadata::*, physics::*, player::*, random::*, utils::*, FPS,
         MAX_PLAYERS,
     };
 }

--- a/src/core/elements/flappy_jellyfish.rs
+++ b/src/core/elements/flappy_jellyfish.rs
@@ -26,13 +26,13 @@ impl FlappyJellyfishMeta {
     }
 }
 
-pub trait AssetGetFlappyJellyfishMeta {
+pub trait FlappyJellyfishMetaSchemaExts {
     /// Try to cast the `asset` to a `JellyfishMeta` and get the
     /// `FlappyJellyfishMeta` from it.
     fn try_get_flappy_meta(&self) -> Option<Handle<FlappyJellyfishMeta>>;
 }
 
-impl AssetGetFlappyJellyfishMeta for SchemaBox {
+impl FlappyJellyfishMetaSchemaExts for SchemaBox {
     fn try_get_flappy_meta(&self) -> Option<Handle<FlappyJellyfishMeta>> {
         self.try_cast_ref::<JellyfishMeta>()
             .ok()

--- a/src/core/elements/flappy_jellyfish.rs
+++ b/src/core/elements/flappy_jellyfish.rs
@@ -63,7 +63,8 @@ pub fn spawn(owner: Entity, jellyfish_ent: Entity) -> StaticSystem<(), ()> {
            assets: Res<AssetServer>,
            mut atlas_sprites: CompMut<AtlasSprite>,
            mut animated_sprites: CompMut<AnimatedSprite>,
-           mut transforms: CompMut<Transform>| {
+           mut transforms: CompMut<Transform>,
+           mut camera_subjects: CompMut<CameraSubject>| {
         let Some(flappy_meta) = element_handles
             .get(jellyfish_ent)
             .map(|element_h| assets.get(element_h.0))
@@ -114,6 +115,7 @@ pub fn spawn(owner: Entity, jellyfish_ent: Entity) -> StaticSystem<(), ()> {
         let mut transf = *transforms.get(owner).unwrap();
         transf.translation += flappy_meta.spawn_offset.extend(0.0);
         transforms.insert(flappy_ent, transf);
+        camera_subjects.insert(flappy_ent, default());
     })
     .system()
 }

--- a/src/core/elements/flappy_jellyfish.rs
+++ b/src/core/elements/flappy_jellyfish.rs
@@ -171,6 +171,7 @@ fn control_flappy_jellyfish(
     player_inputs: Res<MatchInputs>,
     mut explode_flappies: CompMut<ExplodeFlappyJellyfish>,
     mut bodies: CompMut<KinematicBody>,
+    flappy_jellyfishes: Comp<FlappyJellyfish>,
 ) {
     let t = time.delta_seconds();
 
@@ -199,7 +200,9 @@ fn control_flappy_jellyfish(
         if owner_control.jump_just_pressed {
             body.velocity.y += SPEED_JUMP;
         }
+    }
 
+    for (_, (_, body)) in entities.iter_with((&flappy_jellyfishes, &mut bodies)) {
         body.velocity = body.velocity.clamp(MIN_SPEED, MAX_SPEED);
     }
 }

--- a/src/core/elements/flappy_jellyfish.rs
+++ b/src/core/elements/flappy_jellyfish.rs
@@ -162,7 +162,6 @@ pub struct ExplodeFlappyJellyfish;
 fn explode_flappy_jellyfish(
     mut entities: ResMut<Entities>,
     explode_flappies: Comp<ExplodeFlappyJellyfish>,
-    killed_players: Comp<PlayerKilled>,
     flappy_jellyfishes: Comp<FlappyJellyfish>,
     mut jellyfishes: CompMut<Jellyfish>,
     player_indexes: Comp<PlayerIdx>,
@@ -193,16 +192,11 @@ fn explode_flappy_jellyfish(
     let mut explode_flappy_entities =
         SmallVec::<[Entity; 8]>::with_capacity(flappy_jellyfishes.bitset().bit_count());
 
-    for (flappy_ent, (flappy_jellyfish, transform, body)) in
+    for (flappy_ent, (_flappy_jellyfish, transform, body)) in
         entities.iter_with((&flappy_jellyfishes, &transforms, &bodies))
     {
         // If flappy has the explode marker
         if explode_flappies.contains(flappy_ent) {
-            explode_flappy_entities.push(flappy_ent);
-            continue;
-        }
-        // If the owner is dead
-        if killed_players.contains(flappy_jellyfish.owner) {
             explode_flappy_entities.push(flappy_ent);
             continue;
         }

--- a/src/core/elements/jellyfish.rs
+++ b/src/core/elements/jellyfish.rs
@@ -157,8 +157,15 @@ fn dehydrate(
     for (jellyfish_ent, (dehydrate, spawner)) in
         entities.iter_with((&dehydrate_jellyfish, &spawners))
     {
-        player_driving.remove(dehydrate.owner);
-        player_inventories.insert(dehydrate.owner, Inventory(None));
+        if player_inventories
+            .get(dehydrate.owner)
+            .and_then(|inv| inv.0)
+            .filter(|item| *item == jellyfish_ent)
+            .is_some()
+        {
+            player_driving.remove(dehydrate.owner);
+            player_inventories.insert(dehydrate.owner, Inventory(None));
+        }
         commands.add(move |mut entities: ResMut<Entities>| entities.kill(jellyfish_ent));
         hydrated.remove(**spawner);
     }

--- a/src/core/elements/jellyfish.rs
+++ b/src/core/elements/jellyfish.rs
@@ -36,7 +36,7 @@ pub fn session_plugin(session: &mut Session) {
         .stages
         .add_system_to_stage(CoreStage::PreUpdate, hydrate)
         .add_system_to_stage(CoreStage::PreUpdate, dehydrate)
-        .add_system_to_stage(CoreStage::PostUpdate, update_jellyfish_driving);
+        .add_system_to_stage(CoreStage::PostUpdate, update_player_driving);
     flappy_jellyfish::session_plugin(session);
 }
 
@@ -53,6 +53,8 @@ impl Jellyfish {
     }
 }
 
+/// A marker component for players to indicate that they are driving a flappy
+/// jellyfish.
 #[derive(Clone, Debug, Default, HasSchema)]
 pub struct PlayerDrivingJellyfish {
     pub flappy: Entity,
@@ -172,7 +174,7 @@ fn on_jellyfish_drop(entity: Entity, max_ammo: u32) -> StaticSystem<(), ()> {
     .system()
 }
 
-fn update_jellyfish_driving(
+fn update_player_driving(
     entities: Res<Entities>,
     player_indexes: Comp<PlayerIdx>,
     player_inventories: Comp<Inventory>,

--- a/src/core/elements/jellyfish.rs
+++ b/src/core/elements/jellyfish.rs
@@ -117,9 +117,7 @@ fn hydrate(
             );
             item_throws.insert(
                 entity,
-                ItemThrow::strength(*throw_velocity)
-                    .with_spin(*angular_velocity)
-                    .with_system(on_jellyfish_drop(entity, *max_ammo)),
+                ItemThrow::strength(*throw_velocity).with_spin(*angular_velocity),
             );
             element_handles.insert(entity, element_handle);
             atlas_sprites.insert(entity, AtlasSprite::new(*atlas));
@@ -164,14 +162,6 @@ fn dehydrate(
         commands.add(move |mut entities: ResMut<Entities>| entities.kill(jellyfish_ent));
         hydrated.remove(**spawner);
     }
-}
-
-fn on_jellyfish_drop(entity: Entity, max_ammo: u32) -> StaticSystem<(), ()> {
-    (move |mut jellyfishes: CompMut<Jellyfish>| {
-        // Reload
-        jellyfishes.get_mut(entity).unwrap().ammo = max_ammo;
-    })
-    .system()
 }
 
 fn update_player_driving(

--- a/src/core/player.rs
+++ b/src/core/player.rs
@@ -487,6 +487,7 @@ fn hydrate_players(
     mut animation_bank_sprites: CompMut<AnimationBankSprite>,
     mut atlas_sprites: CompMut<AtlasSprite>,
     mut kinematic_bodies: CompMut<KinematicBody>,
+    mut camera_subjects: CompMut<CameraSubject>,
     mut player_layers: CompMut<PlayerLayers>,
     mut player_body_attachments: CompMut<PlayerBodyAttachment>,
     mut transforms: CompMut<Transform>,
@@ -563,6 +564,8 @@ fn hydrate_players(
                 ..default()
             },
         );
+        // debug!(?player_entity, "spawn player");
+        camera_subjects.insert(player_entity, default());
 
         // Spawn the player's fin and face
         let fin_entity = new_entities.next().unwrap();

--- a/src/core/player.rs
+++ b/src/core/player.rs
@@ -564,7 +564,6 @@ fn hydrate_players(
                 ..default()
             },
         );
-        // debug!(?player_entity, "spawn player");
         camera_subjects.insert(player_entity, default());
 
         // Spawn the player's fin and face

--- a/src/core/player/state/states/drive_jellyfish.rs
+++ b/src/core/player/state/states/drive_jellyfish.rs
@@ -4,61 +4,26 @@ pub static ID: Lazy<Ustr> = Lazy::new(|| ustr("core::drive_jellyfish"));
 
 pub fn install(session: &mut Session) {
     PlayerState::add_player_state_transition_system(session, player_state_transition);
-    PlayerState::add_player_state_update_system(session, handle_player_state);
 }
 
 pub fn player_state_transition(
     entities: Res<Entities>,
-    jellyfishes: Comp<Jellyfish>,
-    driving_jellyfishes: Comp<DrivingJellyfish>,
+    player_driving: Comp<PlayerDrivingJellyfish>,
     mut player_states: CompMut<PlayerState>,
     killed_players: Comp<PlayerKilled>,
-    player_inventories: PlayerInventories,
 ) {
-    for (jellyfish_ent, _) in entities.iter_with(&jellyfishes) {
-        if let Some(driving) = driving_jellyfishes.get(jellyfish_ent) {
-            let Some(player_state) = player_states.get_mut(driving.owner) else {
-                continue;
-            };
-            if killed_players.contains(driving.owner) {
+    for (player_ent, player_state) in entities.iter_with(&mut player_states) {
+        if player_driving.contains(player_ent) {
+            if killed_players.contains(player_ent) {
                 continue;
             }
             if player_state.current != *ID {
+                debug!("set player state driving");
                 player_state.current = *ID;
             }
-        } else {
-            let Some(player_state) = player_inventories
-                .find_item(jellyfish_ent)
-                .and_then(|inventory| player_states.get_mut(inventory.player))
-            else {
-                continue;
-            };
-            if player_state.current == *ID {
-                player_state.current = *idle::ID;
-            }
-        }
-    }
-}
-
-pub fn handle_player_state(
-    entities: Res<Entities>,
-    player_indexes: Comp<PlayerIdx>,
-    player_states: Comp<PlayerState>,
-    inventories: Comp<Inventory>,
-    player_inputs: Res<MatchInputs>,
-    mut commands: Commands,
-) {
-    for (player_ent, (player_idx, player_state, inventory)) in
-        entities.iter_with((&player_indexes, &player_states, &inventories))
-    {
-        if player_state.current != *ID {
-            continue;
-        }
-
-        let control = &player_inputs.players[player_idx.0 as usize].control;
-
-        if control.shoot_just_pressed && inventory.is_some() {
-            commands.add(PlayerCommand::use_item(player_ent));
+        } else if player_state.current == *ID {
+            debug!("set player state idle");
+            player_state.current = *idle::ID;
         }
     }
 }

--- a/src/core/player/state/states/drive_jellyfish.rs
+++ b/src/core/player/state/states/drive_jellyfish.rs
@@ -18,11 +18,9 @@ pub fn player_state_transition(
                 continue;
             }
             if player_state.current != *ID {
-                debug!("set player state driving");
                 player_state.current = *ID;
             }
         } else if player_state.current == *ID {
-            debug!("set player state idle");
             player_state.current = *idle::ID;
         }
     }


### PR DESCRIPTION
Take 2 🎬 this is the second iteration of the Jellyfish item, based on Duck Game's [RC Controller](https://duckgame.fandom.com/wiki/RC_Controller).

More tweaks may come in follow-up PRs

## Notable Changes from [v1](https://github.com/fishfolk/jumpy/pull/895)

- The camera follows any entity with the new `CameraSubject` component
  - Entity must also have a `Transform` and `KinematicBody` to work properly
- The flappy jellyfish collides with solids
  - The flappy is now much more jerky and overly responsive to user input, I may add acceleration to the left/right movement so that it floats around more to give it a more natural feel
- Control the jellyfish like Duck Game's RC Controller
- The flappy is tied to the jellyfish hat, not the player
  - If the driver dies/drops the jellyfish the flappy doesn't explode, another player can pick it up and take control
- Despawn & dehydrate the jellyfish item when the flappy explodes

## ToDo

- ~Try to get the jellyfish on the player's head~ (will handle in another PR for cosmetic changes)