### PR TITLE
feat(networking): Re-implement networking from bones + re-add online matches

### DIFF
--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: jetli/wasm-bindgen-action@v0.1.0
         name: 🔧 Wasm Bindgen
         with:
-          version: "0.2.89"
+          version: "0.2.90"
 
       - uses: actions/cache@v3
         name: ♻️ Cache Cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "bones_asset"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "bones_bevy_renderer"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "anyhow",
  "atomicell",
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "bones_framework"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "bones_lib"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "bones_ecs",
  "instant",
@@ -1240,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "bones_matchmaker_proto"
 version = "0.2.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "serde",
 ]
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "bones_schema"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "append-only-vec",
  "bones_schema_macros",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "bones_schema_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1276,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "bones_scripting"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "async-channel",
  "bevy_tasks",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "bones_utils"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "bones_utils_macros",
  "branches",
@@ -1314,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "bones_utils_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "quote",
  "venial",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "quinn_runtime_bevy"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
+source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
 dependencies = [
  "async-executor",
  "async-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78286a81fead796dc4b45ab14f4f02fe29a94423d3587bcfef872b2a8e0a474b"
 dependencies = [
- "glam",
+ "glam 0.24.2",
  "serde",
 ]
 
@@ -694,7 +694,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cfc2a21ea47970a9b1f0f4735af3256a8f204815bd756110051d10f9d909497"
 dependencies = [
- "glam",
+ "glam 0.24.2",
 ]
 
 [[package]]
@@ -750,7 +750,7 @@ dependencies = [
  "bevy_utils",
  "downcast-rs",
  "erased-serde",
- "glam",
+ "glam 0.24.2",
  "once_cell",
  "parking_lot 0.12.1",
  "serde",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "bones_asset"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "bones_bevy_renderer"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1158,7 +1158,7 @@ dependencies = [
  "bevy_prototype_lyon",
  "bones_framework",
  "directories",
- "glam",
+ "glam 0.24.2",
  "serde",
  "serde_yaml",
  "web-sys",
@@ -1167,14 +1167,14 @@ dependencies = [
 [[package]]
 name = "bones_ecs"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "anyhow",
  "atomicell",
  "bitset-core",
  "bones_schema",
  "bones_utils",
- "glam",
+ "glam 0.24.2",
  "once_map",
  "paste",
  "thiserror",
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "bones_framework"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1202,7 +1202,7 @@ dependencies = [
  "fluent-langneg",
  "futures-lite 1.13.0",
  "ggrs",
- "glam",
+ "glam 0.24.2",
  "hex",
  "image",
  "instant",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "bones_lib"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "bones_ecs",
  "instant",
@@ -1240,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "bones_matchmaker_proto"
 version = "0.2.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "serde",
 ]
@@ -1248,13 +1248,13 @@ dependencies = [
 [[package]]
 name = "bones_schema"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "append-only-vec",
  "bones_schema_macros",
  "bones_utils",
  "erased-serde",
- "glam",
+ "glam 0.24.2",
  "humantime",
  "paste",
  "serde",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "bones_schema_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1276,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "bones_scripting"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "async-channel",
  "bevy_tasks",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "bones_utils"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "bones_utils_macros",
  "branches",
@@ -1314,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "bones_utils_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "quote",
  "venial",
@@ -1916,7 +1916,7 @@ checksum = "8fce2eeef77fd4a293a54b62aa00ac9daebfbcda4bf8998c5a815635b004aa1c"
 dependencies = [
  "const_panic",
  "encase_derive",
- "glam",
+ "glam 0.24.2",
  "thiserror",
 ]
 
@@ -2527,8 +2527,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
 dependencies = [
  "bytemuck",
- "mint",
  "serde",
+]
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+dependencies = [
+ "mint",
 ]
 
 [[package]]
@@ -2667,6 +2675,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,7 +2699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cb3df16a7bcb1b5bc092abd55e14f77ca70aea14445026e264586fc62889a10"
 dependencies = [
  "constgebra",
- "glam",
+ "glam 0.24.2",
 ]
 
 [[package]]
@@ -2764,14 +2778,13 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711"
+checksum = "034bbe799d1909622a74d1193aa50147769440040ff36cb2baa947609b0a4e23"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "num-rational",
  "num-traits",
  "png",
  "tiff",
@@ -2963,9 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -3002,6 +3015,7 @@ dependencies = [
  "serde_yaml",
  "shadow-rs",
  "shiftnanigans",
+ "strum",
  "thiserror",
  "tracing",
  "turborand",
@@ -3020,12 +3034,13 @@ dependencies = [
 
 [[package]]
 name = "kira"
-version = "0.8.5"
-source = "git+https://github.com/zicklag/kira.git?branch=feat/sync#ff184e31263652e21d94445b9087dfee04c2ea2b"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf1a7c2430fc76940b1443d7d2f91d92238ec56a053f706357f9f3f09c70ff3"
 dependencies = [
  "atomic-arena",
  "cpal",
- "glam",
+ "glam 0.25.0",
  "mint",
  "ringbuf",
  "send_wrapper",
@@ -3388,7 +3403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
 dependencies = [
  "approx",
- "glam",
+ "glam 0.24.2",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -4073,9 +4088,9 @@ checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "png"
-version = "0.17.10"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
+checksum = "1f6c3c3e617595665b8ea2ff95a86066be38fb121ff920a9c0eb282abcd1da5a"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -4222,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "quinn_runtime_bevy"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#d560443794970526e72c848b4c1ade71ccf4de6a"
+source = "git+https://github.com/fishfolk/bones#3ee624a9ae156e1e7468a0d94e6cda4978612b94"
 dependencies = [
  "async-executor",
  "async-io",
@@ -4614,6 +4629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4955,6 +4976,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5156,9 +5199,9 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
 dependencies = [
  "flate2",
  "jpeg-decoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.1"
+version = "0.69.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2"
+checksum = "a4c69fae65a523209d34240b60abe0c42d33d1045d445c0839d8a4894a736e2d"
 dependencies = [
  "bitflags 2.4.1",
  "cexpr",
@@ -1032,6 +1032,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitfield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitfield-rle"
@@ -1113,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "bones_asset"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -1144,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "bones_bevy_renderer"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1161,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "anyhow",
  "atomicell",
@@ -1177,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "bones_framework"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1225,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "bones_lib"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "bones_ecs",
  "instant",
@@ -1234,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "bones_matchmaker_proto"
 version = "0.2.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "serde",
 ]
@@ -1242,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "bones_schema"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "append-only-vec",
  "bones_schema_macros",
@@ -1260,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "bones_schema_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1270,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "bones_scripting"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "async-channel",
  "bevy_tasks",
@@ -1287,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "bones_utils"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "bones_utils_macros",
  "branches",
@@ -1308,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "bones_utils_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "quote",
  "venial",
@@ -2963,9 +2969,9 @@ checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2977,8 +2983,10 @@ dependencies = [
  "async-channel",
  "bevy_dylib",
  "bevy_tasks",
+ "bitfield",
  "bones_bevy_renderer",
  "bones_framework",
+ "bytemuck",
  "egui_extras",
  "humantime-serde",
  "indexmap 2.1.0",
@@ -2987,6 +2995,7 @@ dependencies = [
  "ordered-float",
  "peg",
  "petgraph",
+ "postcard",
  "puffin",
  "rapier2d",
  "serde",
@@ -4213,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "quinn_runtime_bevy"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#e59db7c7887a1a3832aaa4ea6a89bd4b5e194c5a"
+source = "git+https://github.com/fishfolk/bones#06d5efcace0f07986735fe872590449a85ca2104"
 dependencies = [
  "async-executor",
  "async-io",
@@ -5592,9 +5601,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5602,9 +5611,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -5617,9 +5626,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5629,9 +5638,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5639,9 +5648,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5652,9 +5661,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wayland-scanner"
@@ -5669,9 +5678,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,12 @@ thiserror           = "1.0.48"
 peg                 = "0.8.1"
 egui_extras         = { version = "0.23.0", default-features = false }
 shadow-rs           = { version = "0.25.0", default-features = false }
+postcard               = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy_dylib = "0.11"
+bitfield               = "0.14"
+bytemuck               = "1.12"
 
 # anyhow              = "1.0"
 # async-channel       = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ peg                 = "0.8.1"
 egui_extras         = { version = "0.23.0", default-features = false }
 shadow-rs           = { version = "0.25.0", default-features = false }
 postcard               = { version = "1.0", default-features = false, features = ["alloc"] }
+strum = { version = "0.25.0", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy_dylib = "0.11"

--- a/src/core.rs
+++ b/src/core.rs
@@ -109,7 +109,7 @@ impl SessionRunner for JumpyDefaultMatchRunner {
         {
             let keyboard = world.resource::<KeyboardInputs>();
             let gamepad = world.resource::<GamepadInputs>();
-            self.input_collector.update(
+            self.input_collector.apply_inputs(
                 &world.resource::<PlayerControlMapping>(),
                 &keyboard,
                 &gamepad,
@@ -122,7 +122,8 @@ impl SessionRunner for JumpyDefaultMatchRunner {
                 .resource_mut::<Time>()
                 .advance_exact(Duration::from_secs_f64(STEP));
 
-            let input = self.input_collector.get();
+            self.input_collector.update_just_pressed();
+            let input = self.input_collector.get_current_controls();
             {
                 let mut player_inputs = world.resource_mut::<MatchInputs>();
                 (0..MAX_PLAYERS).for_each(|i| {

--- a/src/core.rs
+++ b/src/core.rs
@@ -137,6 +137,9 @@ impl SessionRunner for JumpyDefaultMatchRunner {
                 });
             }
 
+            // Mark inputs as consumed for this frame
+            self.input_collector.advance_frame();
+
             // Advance the simulation
             stages.run(world);
         };

--- a/src/core.rs
+++ b/src/core.rs
@@ -52,6 +52,8 @@ pub struct MatchPlugin {
     pub player_info: [PlayerInput; MAX_PLAYERS],
     /// The lua plugins to enable for this match.
     pub plugins: Arc<Vec<Handle<LuaPlugin>>>,
+
+    pub session_runner: Box<dyn SessionRunner>,
 }
 
 pub struct MatchPlayerInfo {
@@ -87,7 +89,7 @@ impl SessionPlugin for MatchPlugin {
         session.world.insert_resource(MatchInputs {
             players: self.player_info,
         });
-        session.runner = Box::<JumpyDefaultMatchRunner>::default();
+        session.runner = self.session_runner;
     }
 }
 

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -65,8 +65,11 @@ pub struct PlayerInput {
     pub control: PlayerControl,
     /// The editor inputs the player is making, if any.
     pub editor_input: Option<EditorInput>,
-    /// If this is [`None`] it means the player is an AI.
+    /// If this is [`None`] it means the player is an AI, or remote player in networked game.
     pub control_source: Option<ControlSource>,
+
+    /// Whether or not this is an AI player.
+    pub is_ai: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/core/input.rs
+++ b/src/core/input.rs
@@ -2,6 +2,8 @@
 
 use std::array;
 
+use bones_framework::input::PlayerControls;
+
 use crate::{prelude::*, MAX_PLAYERS};
 
 pub fn install(session: &mut Session) {
@@ -19,6 +21,33 @@ impl Default for MatchInputs {
         Self {
             players: array::from_fn(|_| default()),
         }
+    }
+}
+
+impl PlayerControls<'_, PlayerControl> for MatchInputs {
+    type ControlSource = ControlSource;
+    type ControlMapping = PlayerControlMapping;
+    type InputCollector = PlayerInputCollector;
+
+    fn update_controls(&mut self, collector: &mut PlayerInputCollector) {
+        (0..MAX_PLAYERS).for_each(|i| {
+            let player_input = &mut self.players[i];
+            if let Some(source) = &player_input.control_source {
+                player_input.control = *collector.get_control(i, *source);
+            }
+        });
+    }
+
+    fn get_control_source(&self, player_idx: usize) -> Option<ControlSource> {
+        self.players.get(player_idx).unwrap().control_source
+    }
+
+    fn get_control(&self, player_idx: usize) -> &PlayerControl {
+        &self.players.get(player_idx).unwrap().control
+    }
+
+    fn get_control_mut(&mut self, player_idx: usize) -> &mut PlayerControl {
+        &mut self.players.get_mut(player_idx).unwrap().control
     }
 }
 

--- a/src/core/player.rs
+++ b/src/core/player.rs
@@ -519,9 +519,7 @@ fn hydrate_players(
         let player_has_spawned = &mut players_have_spawned.players[player_idx.0 as usize];
         let player_handle = player_inputs.players[player_idx.0 as usize].selected_player;
         let player_hat = &player_inputs.players[player_idx.0 as usize].selected_hat;
-        let is_ai = player_inputs.players[player_idx.0 as usize]
-            .control_source
-            .is_none();
+        let is_ai = player_inputs.players[player_idx.0 as usize].is_ai;
 
         let meta = assets.get(player_handle);
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -394,7 +394,7 @@ impl<'a>
 impl NetworkPlayerControl<DensePlayerControl> for PlayerControl {
     fn get_dense_input(&self) -> DensePlayerControl {
         let mut dense_control = DensePlayerControl::default();
-        dense_control.set_jump_pressed(self.jump_just_pressed);
+        dense_control.set_jump_pressed(self.jump_pressed);
         dense_control.set_grab_pressed(self.grab_pressed);
         dense_control.set_slide_pressed(self.slide_pressed);
         dense_control.set_shoot_pressed(self.shoot_pressed);

--- a/src/input.rs
+++ b/src/input.rs
@@ -5,6 +5,7 @@ use crate::{
 
 #[cfg(not(target_arch = "wasm32"))]
 use bones_framework::networking::{input::NetworkPlayerControl, proto::DenseMoveDirection};
+use strum::EnumIter;
 
 pub fn game_plugin(game: &mut Game) {
     game.systems.add_startup_system(load_controler_mapping);
@@ -127,7 +128,7 @@ impl GlobalPlayerControls {
 }
 
 /// The source of player control inputs
-#[derive(Debug, Clone, Copy, Default, HasSchema, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, HasSchema, Hash, Eq, PartialEq, EnumIter)]
 #[repr(C, u8)]
 pub enum ControlSource {
     #[default]

--- a/src/input.rs
+++ b/src/input.rs
@@ -33,6 +33,7 @@ fn collect_player_controls(game: &mut Game) {
         let gamepad = game.shared_resource::<GamepadInputs>().unwrap();
         collector.apply_inputs(&mapping, &keyboard, &gamepad);
         collector.update_just_pressed();
+        collector.advance_frame();
         GlobalPlayerControls(
             collector
                 .get_current_controls()

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::{core::JumpyDefaultMatchRunner, prelude::*};
 
 pub struct SessionNames;
 impl SessionNames {
@@ -43,6 +43,7 @@ impl SessionExt for Sessions {
                     map,
                     player_info,
                     plugins,
+                    session_runner: Box::<JumpyDefaultMatchRunner>::default(),
                 });
         } else {
             panic!("Cannot restart game when game is not running");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -51,6 +51,16 @@ pub struct PlayerControlMapping {
     pub keyboard2: PlayerControlSetting,
 }
 
+impl PlayerControlMapping {
+    pub fn map_control_source(&self, source: ControlSource) -> &PlayerControlSetting {
+        match source {
+            ControlSource::Keyboard1 => &self.keyboard1,
+            ControlSource::Keyboard2 => &self.keyboard2,
+            ControlSource::Gamepad(_) => &self.gamepad,
+        }
+    }
+}
+
 /// Binds inputs to player actions
 #[derive(HasSchema, Clone, Debug, Default)]
 #[repr(C)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,3 +1,5 @@
+use strum::IntoEnumIterator;
+
 use crate::prelude::*;
 
 /// Settings plugin
@@ -58,6 +60,11 @@ impl PlayerControlMapping {
             ControlSource::Keyboard2 => &self.keyboard2,
             ControlSource::Gamepad(_) => &self.gamepad,
         }
+    }
+
+    /// Return an iterator for PlayerControlSetting for all control sources.
+    pub fn all_settings(&self) -> impl Iterator<Item = &PlayerControlSetting> {
+        ControlSource::iter().map(|s| self.map_control_source(s))
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,6 +4,9 @@ pub mod main_menu;
 pub mod map_select;
 pub mod pause_menu;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub mod network_game;
+
 #[derive(HasSchema, Clone, Debug)]
 #[repr(C)]
 pub struct UiTheme {

--- a/src/ui/main_menu.rs
+++ b/src/ui/main_menu.rs
@@ -11,6 +11,9 @@ use shadow_rs::shadow;
 // Generate build info.
 shadow!(build_info);
 
+#[cfg(not(target_arch = "wasm32"))]
+mod network_game;
+
 #[derive(HasSchema, Debug, Default, Clone)]
 #[repr(C)]
 pub struct MainMenuMeta {
@@ -110,7 +113,11 @@ fn main_menu_system(world: &World) {
             MenuPage::PlayerSelect => world.run_system(player_select::widget, ui),
             MenuPage::MapSelect { .. } => world.run_system(map_select::widget, ui),
             MenuPage::Credits => world.run_system(credits::widget, ui),
-            MenuPage::NetworkGame => todo!(),
+            MenuPage::NetworkGame =>
+            {
+                #[cfg(not(target_arch = "wasm32"))]
+                world.run_system(network_game::widget, ui)
+            }
         });
 
     egui::CentralPanel::default()
@@ -167,16 +174,18 @@ fn home_menu(
                     ui.ctx().set_state(MenuPage::PlayerSelect);
                 }
 
-                // // Online game
-                // #[cfg(not(target_arch = "wasm32"))]
-                // if BorderedButton::themed(
-                //     &meta.theme.buttons.normal,
-                //     localization.get("online-game"),
-                // )
-                // .min_size(vec2(ui.available_width(), 0.0))
-                // .show(ui)
-                // .clicked()
-                // {}
+                // Online game
+                #[cfg(not(target_arch = "wasm32"))]
+                if BorderedButton::themed(
+                    &meta.theme.buttons.normal,
+                    localization.get("online-game"),
+                )
+                .min_size(vec2(ui.available_width(), 0.0))
+                .show(ui)
+                .clicked()
+                {
+                    ui.ctx().set_state(MenuPage::NetworkGame);
+                }
 
                 // Settings
                 if BorderedButton::themed(&meta.theme.buttons.normal, localization.get("settings"))

--- a/src/ui/main_menu.rs
+++ b/src/ui/main_menu.rs
@@ -4,7 +4,7 @@ use super::ImageMeta;
 
 mod credits;
 mod map_select;
-mod player_select;
+pub mod player_select;
 mod settings;
 use shadow_rs::shadow;
 

--- a/src/ui/main_menu/map_select.rs
+++ b/src/ui/main_menu/map_select.rs
@@ -1,10 +1,19 @@
-use crate::core::MatchPlugin;
+use crate::core::{JumpyDefaultMatchRunner, MatchPlugin};
 use crate::prelude::*;
 
 use crate::ui::map_select::{map_select_menu, MapSelectAction};
 
 use super::player_select::PlayerSelectState;
 use super::MenuPage;
+
+#[cfg(not(target_arch = "wasm32"))]
+use bones_framework::networking::{GgrsSessionRunner, GgrsSessionRunnerInfo, NetworkMatchSocket};
+
+/// Network message that may be sent when selecting a map.
+#[derive(Serialize, Deserialize)]
+pub enum MapSelectMessage {
+    SelectMap(NetworkHandle<MapMeta>),
+}
 
 pub fn widget(
     ui: In<&mut egui::Ui>,
@@ -13,14 +22,46 @@ pub fn widget(
     mut sessions: ResMut<Sessions>,
     mut session_options: ResMut<SessionOptions>,
     assets: Res<AssetServer>,
+
+    #[cfg(not(target_arch = "wasm32"))] network_socket: Option<Res<NetworkMatchSocket>>,
 ) {
-    let select_action = world.run_system(map_select_menu, ());
+    let mut select_action = MapSelectAction::None;
+
+    // Get map select action from network
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(MapSelectAction::SelectMap(map_meta)) =
+        handle_match_setup_messages(&network_socket, &assets)
+    {
+        select_action = MapSelectAction::SelectMap(map_meta);
+    }
+
+    // If no network action - update action from UI
+    if matches!(select_action, MapSelectAction::None) {
+        select_action = world.run_system(map_select_menu, ());
+
+        #[cfg(not(target_arch = "wasm32"))]
+        // Replicate local action
+        replicate_map_select_action(&select_action, &network_socket, &assets);
+    }
 
     match select_action {
         MapSelectAction::None => (),
-        MapSelectAction::SelectMap(map_meta) => {
+        MapSelectAction::SelectMap(map_handle) => {
             session_options.delete = true;
             ui.ctx().set_state(MenuPage::Home);
+
+            #[cfg(not(target_arch = "wasm32"))]
+            let session_runner: Box<dyn SessionRunner> = match network_socket {
+                Some(socket) => Box::new(GgrsSessionRunner::<NetworkInputConfig>::new(
+                    FPS,
+                    GgrsSessionRunnerInfo::from(socket.as_ref()),
+                )),
+                None => Box::<JumpyDefaultMatchRunner>::default(),
+            };
+            #[cfg(target_arch = "wasm32")]
+            let session_runner = Box::<JumpyDefaultMatchRunner>::default();
+
+            let map_meta = assets.get(map_handle).clone();
 
             let player_select_state = ui.ctx().get_state::<PlayerSelectState>();
             sessions.start_game(MatchPlugin {
@@ -35,12 +76,67 @@ pub fn widget(
                         control_source: slot.control_source,
                         editor_input: default(),
                         control: default(),
+                        is_ai: slot.is_ai,
                     }
                 }),
                 plugins: meta.get_plugins(&assets),
+                session_runner,
             });
             ui.ctx().set_state(PlayerSelectState::default());
         }
         MapSelectAction::GoBack => ui.ctx().set_state(MenuPage::PlayerSelect),
     }
+}
+
+/// Send a MapSelectMessage over network if local player has selected a map.
+#[cfg(not(target_arch = "wasm32"))]
+fn replicate_map_select_action(
+    action: &MapSelectAction,
+    socket: &Option<Res<NetworkMatchSocket>>,
+    asset_server: &AssetServer,
+) {
+    use bones_framework::networking::SocketTarget;
+    if let Some(socket) = socket {
+        if let MapSelectAction::SelectMap(map) = action {
+            info!("Sending network SelectMap message.");
+            socket.send_reliable(
+                SocketTarget::All,
+                &postcard::to_allocvec(&MapSelectMessage::SelectMap(
+                    map.network_handle(asset_server),
+                ))
+                .unwrap(),
+            );
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn handle_match_setup_messages(
+    socket: &Option<Res<NetworkMatchSocket>>,
+    asset_server: &AssetServer,
+) -> Option<MapSelectAction> {
+    if let Some(socket) = socket {
+        let datas: Vec<(usize, Vec<u8>)> = socket.recv_reliable();
+
+        for (_player, data) in datas {
+            match postcard::from_bytes::<MapSelectMessage>(&data) {
+                Ok(message) => match message {
+                    MapSelectMessage::SelectMap(map_handle) => {
+                        info!("Map select message received, starting game");
+
+                        let handle = map_handle.into_handle(asset_server);
+                        return Some(MapSelectAction::SelectMap(handle));
+                    }
+                },
+                Err(e) => {
+                    // TODO: The second player in an online match is having this triggered by
+                    // picking up a `ConfirmSelection` message, that might have been sent to
+                    // _itself_.
+                    warn!("Ignoring network message that was not understood: {e} data: {data:?}");
+                }
+            }
+        }
+    }
+
+    None
 }

--- a/src/ui/main_menu/network_game.rs
+++ b/src/ui/main_menu/network_game.rs
@@ -1,0 +1,14 @@
+use crate::ui::network_game::network_game_menu;
+
+use super::*;
+
+// TODO remove ui param?
+pub fn widget(_ui: In<&mut egui::Ui>, world: &World) {
+    // let mut params: MatchmakingMenu = state.get_mut(world);
+    // let menu_input = params.menu_input.single();
+
+    world.run_system(network_game_menu, ());
+
+    // TODO
+    // params.state.ping_update_timer.tick(params.time.delta());
+}

--- a/src/ui/main_menu/player_select.rs
+++ b/src/ui/main_menu/player_select.rs
@@ -1,5 +1,5 @@
-// #[cfg(not(target_arch = "wasm32"))]
-// use crate::networking::{NetworkMatchSocket, SocketTarget};
+#[cfg(not(target_arch = "wasm32"))]
+use bones_framework::networking::{NetworkMatchSocket, SocketTarget};
 
 use crate::PackMeta;
 
@@ -8,7 +8,7 @@ use super::*;
 // const GAMEPAD_ACTION_IDX: usize = 0;
 // const KEYPAD_ACTION_IDX: usize = 1;
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, HasSchema)]
 pub struct PlayerSelectState {
     pub slots: [PlayerSlot; MAX_PLAYERS],
     /// Cache of available players from the game and packs.
@@ -33,13 +33,13 @@ impl PlayerSlot {
     }
 }
 
-// /// Network message that may be sent during player selection.
-// #[derive(Serialize, Deserialize)]
-// pub enum PlayerSelectMessage {
-//     SelectPlayer(Handle<PlayerMeta>),
-//     SelectHat(Option<Handle<HatMeta>>),
-//     ConfirmSelection(bool),
-// }
+/// Network message that may be sent during player selection.
+#[derive(Serialize, Deserialize)]
+pub enum PlayerSelectMessage {
+    SelectPlayer(NetworkHandle<PlayerMeta>),
+    SelectHat(Option<NetworkHandle<HatMeta>>),
+    ConfirmSelection(bool),
+}
 
 pub fn widget(
     mut ui: In<&mut egui::Ui>,
@@ -47,16 +47,20 @@ pub fn widget(
     localization: Localization<GameMeta>,
     controls: Res<GlobalPlayerControls>,
     world: &World,
+
+    #[cfg(not(target_arch = "wasm32"))] asset_server: Res<AssetServer>,
+    #[cfg(not(target_arch = "wasm32"))] network_socket: Option<Res<NetworkMatchSocket>>,
 ) {
-    let is_online = false;
     let mut state = ui.ctx().get_state::<PlayerSelectState>();
     ui.ctx().set_state(EguiInputSettings {
         disable_keyboard_input: true,
         disable_gamepad_input: true,
     });
 
-    // #[cfg(not(target_arch = "wasm32"))]
-    // handle_match_setup_messages(&mut params);
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(socket) = network_socket.as_ref() {
+        handle_match_setup_messages(socket, &mut state, &asset_server);
+    }
 
     // Whether or not the continue button should be enabled
     let mut ready_players = 0;
@@ -71,15 +75,15 @@ pub fn widget(
     }
     let may_continue = ready_players >= 1 && unconfirmed_players == 0;
 
-    // #[cfg(not(target_arch = "wasm32"))]
-    // if let Some(socket) = &params.network_socket {
-    //     if may_continue {
-    //         // The first player picks the map
-    //         let is_waiting = socket.player_idx() != 0;
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(socket) = network_socket.as_ref() {
+        if may_continue {
+            // The first player picks the map
+            let is_waiting = socket.player_idx() != 0;
 
-    //         *params.menu_page = MenuPage::MapSelect { is_waiting };
-    //     }
-    // }
+            ui.ctx().set_state(MenuPage::MapSelect { is_waiting });
+        }
+    }
 
     let bigger_text_style = &meta
         .theme
@@ -96,8 +100,13 @@ pub fn widget(
     ui.vertical_centered(|ui| {
         ui.add_space(heading_text_style.size / 4.0);
 
+        #[cfg(target_arch = "wasm32")]
+        let is_network = false;
+        #[cfg(not(target_arch = "wasm32"))]
+        let is_network = network_socket.is_some();
+
         // Title
-        if is_online {
+        if is_network {
             ui.label(heading_text_style.rich(localization.get("online-game")));
         } else {
             ui.label(heading_text_style.rich(localization.get("local-game")));
@@ -133,10 +142,10 @@ pub fn widget(
                     ui.ctx().set_state(EguiInputSettings::default());
                     ui.ctx().set_state(PlayerSelectState::default());
 
-                    // #[cfg(not(target_arch = "wasm32"))]
-                    // if let Some(socket) = params.network_socket {
-                    //     socket.close();
-                    // }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    if let Some(socket) = network_socket {
+                        socket.close();
+                    }
                 }
 
                 ui.add_space(button_spacing);
@@ -180,29 +189,35 @@ pub fn widget(
     ui.ctx().set_state(state);
 }
 
-// #[cfg(not(target_arch = "wasm32"))]
-// fn handle_match_setup_messages(params: &mut PlayerSelectMenu) {
-//     if let Some(socket) = &params.network_socket {
-//         let datas: Vec<(usize, Vec<u8>)> = socket.recv_reliable();
-
-//         for (player, data) in datas {
-//             match postcard::from_bytes::<PlayerSelectMessage>(&data) {
-//                 Ok(message) => match message {
-//                     PlayerSelectMessage::SelectPlayer(player_handle) => {
-//                         params.player_select_state.slots[player].selected_player = player_handle;
-//                     }
-//                     PlayerSelectMessage::ConfirmSelection(confirmed) => {
-//                         params.player_select_state.slots[player].confirmed = confirmed;
-//                     }
-//                     PlayerSelectMessage::SelectHat(hat) => {
-//                         params.player_select_state.slots[player].selected_hat = hat;
-//                     }
-//                 },
-//                 Err(e) => warn!("Ignoring network message that was not understood: {e}"),
-//             }
-//         }
-//     }
 // }
+
+#[cfg(not(target_arch = "wasm32"))]
+fn handle_match_setup_messages(
+    network_socket: &NetworkMatchSocket,
+    player_select_state: &mut PlayerSelectState,
+    asset_server: &AssetServer,
+) {
+    let datas: Vec<(usize, Vec<u8>)> = network_socket.recv_reliable();
+
+    for (player, data) in datas {
+        match postcard::from_bytes::<PlayerSelectMessage>(&data) {
+            Ok(message) => match message {
+                PlayerSelectMessage::SelectPlayer(player_handle) => {
+                    let player_handle = player_handle.into_handle(asset_server);
+                    player_select_state.slots[player].selected_player = player_handle;
+                }
+                PlayerSelectMessage::ConfirmSelection(confirmed) => {
+                    player_select_state.slots[player].confirmed = confirmed;
+                }
+                PlayerSelectMessage::SelectHat(hat) => {
+                    let hat = hat.map(|hat| hat.into_handle(asset_server));
+                    player_select_state.slots[player].selected_hat = hat;
+                }
+            },
+            Err(e) => warn!("Ignoring network message that was not understood: {e}"),
+        }
+    }
+}
 
 fn player_select_panel(
     mut params: In<(&mut egui::Ui, usize, &mut PlayerSelectState)>,
@@ -212,6 +227,7 @@ fn player_select_panel(
     localization: Localization<GameMeta>,
     mapping: Res<PlayerControlMapping>,
     world: &World,
+    #[cfg(not(target_arch = "wasm32"))] network_socket: Option<Res<NetworkMatchSocket>>,
 ) {
     let (ui, slot_id, state) = &mut *params;
 
@@ -242,76 +258,45 @@ fn player_select_panel(
         }
     }
 
+    #[cfg(target_arch = "wasm32")]
     let is_network = false;
-    // #[cfg(target_arch = "wasm32")]
-    // let is_network = false;
-    // #[cfg(not(target_arch = "wasm32"))]
-    // let is_network = params.network_socket.is_some();
+    #[cfg(not(target_arch = "wasm32"))]
+    let is_network = network_socket.is_some();
 
-    // let player_map = params
-    //     .players
-    //     .iter()
-    //     .find(|(player_idx, _, _)| player_idx.0 == player_id)
-    //     .unwrap()
-    //     .2;
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(socket) = network_socket.as_ref() {
+        // Don't show panels for non-connected players.
+        if *slot_id + 1 > socket.player_count() {
+            return;
+        } else {
+            state.slots[*slot_id].active = true;
+        }
+    }
 
-    // #[cfg(not(target_arch = "wasm32"))]
-    // let dummy_actions = default();
-    // let (player_actions, player_action_map) = if is_network {
-    //     // #[cfg(not(target_arch = "wasm32"))]
-    //     // if let Some(socket) = &params.network_socket {
-    //     //     let actions = if player_id == socket.player_idx() {
-    //     //         params
-    //     //             .players
-    //     //             .iter()
-    //     //             .find(|(player_idx, _, _)| player_idx.0 == 0)
-    //     //             .unwrap()
-    //     //             .1
-    //     //     } else {
-    //     //         &dummy_actions
-    //     //     };
-    //     //     let map = None;
-    //     //     (actions, map)
-    //     // } else {
-    //     //     unreachable!();
-    //     // }
-
-    //     // #[cfg(target_arch = "wasm32")]
-    //     // unreachable!()
-    // } else {
-    //     let actions = players
-    //         .iter()
-    //         .find(|(player_idx, _, _)| player_idx.0 == player_id)
-    //         .unwrap()
-    //         .1;
-    //     let map = Some(get_player_actions(player_id, player_map));
-    //     (actions, map)
-    // };
-
-    // #[cfg(not(target_arch = "wasm32"))]
-    // if let Some(socket) = &params.network_socket {
-    //     // Don't show panels for non-connected players.
-    //     if player_id + 1 > socket.player_count() {
-    //         return;
-    //     } else {
-    //         slot.active = true;
-    //     }
-    // }
-
-    // Get the ID of the first un-occupied slot
-    let next_open_slot = state
+    let is_next_open_slot = state
         .slots
         .iter()
         .enumerate()
-        .find_map(|(i, slot)| (!slot.active).then_some(i));
+        .any(|(i, slot)| (!slot.active && i == *slot_id));
+
+    #[cfg(not(target_arch = "wasm32"))]
+    let slot_allows_new_player = if is_network {
+        {
+            let player_idx = network_socket.as_ref().unwrap().player_idx();
+            *slot_id == player_idx
+        }
+    } else {
+        is_next_open_slot
+    };
+    #[cfg(target_arch = "wasm32")]
+    let slot_allows_new_player = is_next_open_slot;
 
     // Check if a new player is trying to join
     let new_player_join = controls.iter().find_map(|(source, control)| {
         (
             // If this control input is pressing the join button
             control.menu_confirm_just_pressed &&
-            // And this is the next open slot
-            next_open_slot == Some(*slot_id) &&
+            slot_allows_new_player &&
             // And this control source is not bound to a player slot already
             !state
             .slots
@@ -366,14 +351,14 @@ fn player_select_panel(
     if player_control.menu_confirm_just_pressed && new_player_join.is_none() {
         slot.confirmed = true;
 
-        // #[cfg(not(target_arch = "wasm32"))]
-        // if let Some(socket) = &params.network_socket {
-        //     socket.send_reliable(
-        //         SocketTarget::All,
-        //         &postcard::to_allocvec(&PlayerSelectMessage::ConfirmSelection(slot.confirmed))
-        //             .unwrap(),
-        //     );
-        // }
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(socket) = network_socket.as_ref() {
+            socket.send_reliable(
+                SocketTarget::All,
+                &postcard::to_allocvec(&PlayerSelectMessage::ConfirmSelection(slot.confirmed))
+                    .unwrap(),
+            );
+        }
     } else if player_control.menu_back_just_pressed {
         if !is_network {
             if slot.confirmed {
@@ -386,14 +371,14 @@ fn player_select_panel(
             slot.confirmed = false;
         }
 
-        // #[cfg(not(target_arch = "wasm32"))]
-        // if let Some(socket) = &params.network_socket {
-        //     socket.send_reliable(
-        //         SocketTarget::All,
-        //         &postcard::to_allocvec(&PlayerSelectMessage::ConfirmSelection(slot.confirmed))
-        //             .unwrap(),
-        //     );
-        // }
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(socket) = network_socket.as_ref() {
+            socket.send_reliable(
+                SocketTarget::All,
+                &postcard::to_allocvec(&PlayerSelectMessage::ConfirmSelection(slot.confirmed))
+                    .unwrap(),
+            );
+        }
     } else if player_control.just_moved {
         let direction = player_control.move_direction;
 
@@ -419,14 +404,16 @@ fn player_select_panel(
             };
             slot.selected_hat = state.hats[next_idx];
 
-            // #[cfg(not(target_arch = "wasm32"))]
-            // if let Some(socket) = &params.network_socket {
-            //     socket.send_reliable(
-            //         SocketTarget::All,
-            //         &postcard::to_allocvec(&PlayerSelectMessage::SelectHat(player_hat.clone()))
-            //             .unwrap(),
-            //     );
-            // }
+            #[cfg(not(target_arch = "wasm32"))]
+            if let Some(socket) = network_socket.as_ref() {
+                socket.send_reliable(
+                    SocketTarget::All,
+                    &postcard::to_allocvec(&PlayerSelectMessage::SelectHat(
+                        slot.selected_hat.map(|x| x.network_handle(&asset_server)),
+                    ))
+                    .unwrap(),
+                );
+            }
 
             // Select player skin if the player has not be confirmed
         } else {
@@ -447,18 +434,18 @@ fn player_select_panel(
                     idx as usize
                 }
             };
-            slot.selected_player = state.players[next_idx];
+            *player_handle = state.players[next_idx];
 
-            // #[cfg(not(target_arch = "wasm32"))]
-            // if let Some(socket) = &params.network_socket {
-            //     socket.send_reliable(
-            //         SocketTarget::All,
-            //         &postcard::to_allocvec(&PlayerSelectMessage::SelectPlayer(
-            //             player_handle.clone(),
-            //         ))
-            //         .unwrap(),
-            //     );
-            // }
+            #[cfg(not(target_arch = "wasm32"))]
+            if let Some(socket) = network_socket.as_ref() {
+                socket.send_reliable(
+                    SocketTarget::All,
+                    &postcard::to_allocvec(&PlayerSelectMessage::SelectPlayer(
+                        player_handle.network_handle(&asset_server),
+                    ))
+                    .unwrap(),
+                );
+            }
         }
     }
 
@@ -474,38 +461,28 @@ fn player_select_panel(
             let heading_font = &meta.theme.font_styles.heading.with_color(panel.font_color);
 
             // Marker for current player in online matches
-            // #[cfg(not(target_arch = "wasm32"))]
-            // if let Some(socket) = &params.network_socket {
-            //     if socket.player_idx() == player_id {
-            //         ui.vertical_centered(|ui| {
-            //             ui.themed_label(normal_font, &params.localization.get("you-marker"));
-            //         });
-            //     } else {
-            //         ui.add_space(normal_font.size);
-            //     }
-            // } else {
-            //     ui.add_space(normal_font.size);
-            // }
+            #[cfg(not(target_arch = "wasm32"))]
+            if let Some(socket) = network_socket {
+                if socket.player_idx() == *slot_id {
+                    ui.vertical_centered(|ui| {
+                        ui.label(normal_font.rich(localization.get("you-marker")));
+                    });
+                } else {
+                    ui.add_space(normal_font.size);
+                }
+            } else {
+                ui.add_space(normal_font.size);
+            }
 
             ui.add_space(normal_font.size);
 
             if slot.active {
-                let confirm_binding = slot.control_source.map(|s| {
-                    match s {
-                        ControlSource::Keyboard1 => &mapping.keyboard1.menu_confirm,
-                        ControlSource::Keyboard2 => &mapping.keyboard2.menu_confirm,
-                        ControlSource::Gamepad(_) => &mapping.gamepad.menu_confirm,
-                    }
-                    .to_string()
-                });
-                let back_binding = slot.control_source.map(|s| {
-                    match s {
-                        ControlSource::Keyboard1 => &mapping.keyboard1.menu_back,
-                        ControlSource::Keyboard2 => &mapping.keyboard2.menu_back,
-                        ControlSource::Gamepad(_) => &mapping.gamepad.menu_back,
-                    }
-                    .to_string()
-                });
+                let confirm_binding = slot
+                    .control_source
+                    .map(|s| mapping.map_control_source(s).menu_confirm.to_string());
+                let back_binding = slot
+                    .control_source
+                    .map(|s| mapping.map_control_source(s).menu_back.to_string());
                 ui.vertical_centered(|ui| {
                     let player_meta = asset_server.get(slot.selected_player);
                     let hat_meta = slot
@@ -523,12 +500,14 @@ fn player_select_panel(
                             },
                         )));
 
-                        ui.label(normal_font.rich(localization.get_with(
-                            "press-button-to-remove",
-                            &fluent_args! {
-                                "button" => back_binding.as_ref().unwrap().as_str()
-                            },
-                        )));
+                        if !is_network {
+                            ui.label(normal_font.rich(localization.get_with(
+                                "press-button-to-remove",
+                                &fluent_args! {
+                                    "button" => back_binding.as_ref().unwrap().as_str()
+                                },
+                            )));
+                        }
                     } else {
                         ui.label(normal_font.rich(localization.get("waiting")));
                     }

--- a/src/ui/main_menu/player_select.rs
+++ b/src/ui/main_menu/player_select.rs
@@ -24,11 +24,12 @@ pub struct PlayerSlot {
     pub selected_player: Handle<PlayerMeta>,
     pub selected_hat: Option<Handle<HatMeta>>,
     pub control_source: Option<ControlSource>,
+    pub is_ai: bool,
 }
 
 impl PlayerSlot {
     pub fn is_ai(&self) -> bool {
-        self.control_source.is_none()
+        self.is_ai
     }
 }
 
@@ -514,7 +515,7 @@ fn player_select_panel(
 
                     ui.label(normal_font.rich(localization.get("pick-a-fish")));
 
-                    if !slot.confirmed {
+                    if !slot.confirmed && slot.control_source.is_some() {
                         ui.label(normal_font.rich(localization.get_with(
                             "press-button-to-lock-in",
                             &fluent_args! {
@@ -535,7 +536,7 @@ fn player_select_panel(
                     ui.vertical_centered(|ui| {
                         ui.set_height(heading_font.size * 1.5);
 
-                        if slot.confirmed && !slot.is_ai() {
+                        if slot.confirmed && !slot.is_ai() && slot.control_source.is_some() {
                             ui.label(
                                 heading_font
                                     .with_color(meta.theme.colors.positive)
@@ -549,7 +550,7 @@ fn player_select_panel(
                                 },
                             )));
                         }
-                        if slot.is_ai() {
+                        if !is_network && *slot_id != 0 && slot.is_ai() {
                             ui.label(
                                 heading_font
                                     .with_color(meta.theme.colors.positive)
@@ -566,6 +567,7 @@ fn player_select_panel(
                                 slot.confirmed = false;
                                 slot.active = false;
                                 slot.control_source = None;
+                                slot.is_ai = false;
                             }
                         }
                     });
@@ -616,6 +618,7 @@ fn player_select_panel(
                         .show(ui)
                         .clicked()
                         {
+                            slot.is_ai = true;
                             slot.confirmed = true;
                             slot.active = true;
                             let rand_idx = THREAD_RNG.with(|rng| rng.usize(0..state.players.len()));

--- a/src/ui/map_select.rs
+++ b/src/ui/map_select.rs
@@ -56,13 +56,9 @@ pub fn map_select_menu(
                     let menu_page_state = ui.ctx().get_state::<MenuPage>();
                     let is_waiting = match menu_page_state {
                         MenuPage::MapSelect { is_waiting } => is_waiting,
-                        _ => {
-                            warn!(
-                                "On map select page, but MenuPage state is not MenuPage::MapSelect.
-                                   Client may be stuck waiting for map select erroneously. "
-                            );
-                            true
-                        }
+                        // If we are not on the map select menu page it means we are selecting
+                        // a map from the pause menu.
+                        _ => false,
                     };
                     if is_waiting {
                         ui.label(

--- a/src/ui/network_game.rs
+++ b/src/ui/network_game.rs
@@ -1,0 +1,554 @@
+use bones_framework::networking::online::SearchState;
+
+use crate::prelude::*;
+
+use super::main_menu::MenuPage;
+
+#[derive(Clone, Debug, Default)]
+pub enum NetworkGameAction {
+    #[default]
+    None,
+    GoBack,
+}
+
+#[derive(Default, Clone)]
+pub enum LanMode {
+    #[default]
+    Join,
+    Host {
+        service_name: String,
+        player_count: usize,
+    },
+}
+
+#[derive(Eq, PartialEq, Clone)]
+pub struct OnlineState {
+    player_count: usize,
+    matchmaking_server: String,
+    search_state: SearchState,
+}
+
+impl Default for OnlineState {
+    fn default() -> Self {
+        Self {
+            player_count: 2,
+            matchmaking_server: String::new(),
+            search_state: default(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum MatchKind {
+    Lan(LanMode),
+    Online(OnlineState),
+}
+
+impl Default for MatchKind {
+    fn default() -> Self {
+        MatchKind::Lan(LanMode::Join)
+    }
+}
+
+#[derive(Default, PartialEq, Eq, Clone, Copy)]
+pub enum NetworkGameStatus {
+    #[default]
+    Idle,
+    Joining,
+    Hosting,
+    Searching,
+}
+
+#[derive(Clone)]
+pub struct NetworkGameState {
+    match_kind: MatchKind,
+    // lan_service_discovery_recv: Option<mdns_sd::Receiver<mdns_sd::ServiceEvent>>,
+    // service_info: Option<mdns_sd::ServiceInfo>,
+    status: NetworkGameStatus,
+    joined_players: usize,
+    lan_servers: Vec<lan::ServerInfo>,
+    ping_update_timer: Timer,
+}
+
+impl Default for NetworkGameState {
+    fn default() -> Self {
+        Self {
+            match_kind: default(),
+            // lan_service_discovery_recv: default(),
+            // service_info: default(),
+            status: default(),
+            lan_servers: default(),
+            joined_players: default(),
+            ping_update_timer: Timer::new(Duration::from_secs(1), TimerMode::Repeating),
+        }
+    }
+}
+
+pub fn network_game_menu(
+    world: &World,
+    // commands: &mut Commands,
+    localization: Localization<GameMeta>,
+    meta: Root<GameMeta>,
+    ctx: Res<EguiCtx>,
+    player_controls: Res<GlobalPlayerControls>,
+    storage: ResMut<Storage>,
+) //-> NetworkGameAction {
+{
+    // if player_controls.values().any(|x| x.menu_back_just_pressed) {
+    //     return NetworkGameAction::GoBack;
+    // }
+
+    let bigger_text_style = &meta.theme.font_styles.bigger;
+    let normal_text_style = &meta.theme.font_styles.normal;
+    let smaller_text_style = &meta.theme.font_styles.smaller;
+    let heading_text_style = &meta.theme.font_styles.heading;
+    let normal_button_style = &meta.theme.buttons.normal;
+    let small_button_style = &meta.theme.buttons.small;
+
+    // TODO CentralPanel ok?
+    egui::CentralPanel::default()
+        .frame(egui::Frame::none())
+        .show(&ctx, |ui| {
+            ui.vertical_centered(|ui| {
+                ui.add_space(heading_text_style.size / 4.0);
+                ui.label(heading_text_style.rich(localization.get("network-game")));
+                ui.label(bigger_text_style.rich(localization.get("configure-match")));
+                ui.add_space(heading_text_style.size * 4.0);
+            });
+
+            // TODO: set state at end. Is it initialiezd?
+            let mut state = ui.ctx().get_state::<NetworkGameState>();
+
+
+            let available_size = ui.available_size();
+            let x_margin = available_size.x / 4.0;
+            let outer_margin = egui::style::Margin::symmetric(x_margin, 0.0);
+
+            BorderedFrame::new(&meta.theme.panel.border)
+                .margin(outer_margin)
+                .padding(meta.theme.panel.padding)
+                .show(ui, |ui| {
+                    ui.set_width(ui.available_width());
+
+                    ui.horizontal(|ui| {
+                        // Lan tab
+                        // let mut lan = egui::RichText::new(localization.get("lan"));
+                        // if matches!(state.match_kind, MatchKind::Lan(..)) {
+                        //     lan = lan.underline();
+                        // }
+                        // if BorderedButton::themed(normal_button_style, lan)
+                        //     .show(ui)
+                        //     .clicked()
+                        // {
+                        //     state.match_kind = MatchKind::Lan(default());
+                        // }
+
+                        // Online tab
+                        let mut online = egui::RichText::new(localization.get("online"));
+                        if matches!(state.match_kind, MatchKind::Online(..)) {
+                            online = online.underline();
+                        }
+                        if BorderedButton::themed(normal_button_style, online)
+                            .show(ui)
+                            .clicked()
+                        {
+                            state.match_kind = MatchKind::Online(default());
+                        }
+                        match &mut state.match_kind {
+                            MatchKind::Lan(_mode) => {
+                                // ui.with_layout(
+                                //     egui::Layout::right_to_left(egui::Align::Center),
+                                //     |ui| {
+                                //         ui.horizontal(|ui| {
+                                //             // Host tab
+                                //             let mut host =
+                                //                 egui::RichText::new(localization.get("host"));
+                                //             if matches!(mode, LanMode::Host { .. }) {
+                                //                 host = host.underline();
+                                //             }
+                                //             if BorderedButton::themed(
+                                //                 &meta.theme.buttons.small,
+                                //                 host,
+                                //             )
+                                //             .show(ui)
+                                //             .clicked()
+                                //             {
+                                //                 *mode = LanMode::Host {
+                                //                     service_name: localization.get("fish-fight").into_owned(),
+                                //                     player_count: 2,
+                                //                 };
+                                //             }
+
+                                //             // Join tab
+                                //             let mut join =
+                                //                 egui::RichText::new(localization.get("join"));
+                                //             if matches!(mode, LanMode::Join) {
+                                //                 join = join.underline();
+                                //             }
+                                //             if BorderedButton::themed(
+                                //                 &meta.theme.buttons.small,
+                                //                 join,
+                                //             )
+                                //             .show(ui)
+                                //             .clicked()
+                                //             {
+                                //                 *mode = LanMode::Join
+                                //             }
+                                //         });
+                                //     },
+                                // );
+                            },
+                            MatchKind::Online(_online_state) => {
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.label(
+                                            normal_text_style.rich(localization.get("search-for-match"))
+                                        );
+                                    },
+                                );
+                            }
+                        }
+                    });
+
+                    let NetworkGameState {
+                        match_kind,
+                        // lan_service_discovery_recv,
+                        lan_servers: _,
+                        // service_info: host_info,
+                        status,
+                        ping_update_timer: _,
+                        joined_players: _,
+                    } = &mut state;
+
+                    ui.separator();
+                    ui.add_space(normal_text_style.size);
+
+                    match match_kind {
+                        // TODO
+                        // LAN game
+                        MatchKind::Lan(mode) => match mode {
+                            LanMode::Join => {
+                                // Stop any running server
+                                // if let Some(service_info) = host_info.take() {
+                                //     lan::stop_server(&service_info);
+                                //     *status = Status::Idle;
+                                // }
+                                // lan::prepare_to_join(lan_servers, lan_service_discovery_recv, ping_update_timer);
+
+                                // if *status != Status::Joining {
+                                //     ui.label(
+                                //         normal_text_style.rich(localization.get("servers"));
+                                //     );
+                                //     ui.add_space(normal_text_style.size / 2.0);
+
+                                //     ui.indent("servers", |ui| {
+                                //         for server in lan_servers.iter() {
+                                //             ui.horizontal(|ui| {
+                                //                 if BorderedButton::themed(
+                                //                     &params.game.ui_theme.button_styles.normal,
+                                //                     server.service.get_hostname().trim_end_matches('.'),
+                                //                 )
+                                //                 .min_size(vec2(ui.available_width() * 0.8, 0.0))
+                                //                 .show(ui)
+                                //                 .clicked()
+                                //                 {
+                                //                     lan::join_server(server);
+                                //                     *status = Status::Joining;
+                                //                 }
+
+                                //                 let label_text = egui::RichText::new(format!(
+                                //                     "🖧 {}ms",
+                                //                     server
+                                //                         .ping
+                                //                         .map(|x| x.to_string())
+                                //                         .unwrap_or("?".into())
+                                //                 ))
+                                //                 .size(normal_text_style.size);
+                                //                 ui.label(label_text)
+                                //             });
+                                //         }
+
+                                //         if lan_servers.is_empty() {
+                                //             ui.themed_label(
+                                //                 normal_text_style,
+                                //                 &localization.get("no-servers"),
+                                //             );
+                                //         }
+                                //     });
+
+                                // // If we are trying to join a match.
+                                // } else {
+                                //     ui.themed_label(
+                                //         normal_text_style,
+                                //         &localization.get("joining"),
+                                //     );
+
+                                //     if let Some(lan_socket) = lan::wait_game_start() {
+                                //         commands.insert_resource(NetworkMatchSocket(
+                                //             Box::new(lan_socket),
+                                //         ));
+
+                                //         *status = default();
+
+                                // ui.ctx().set_state(MenuPage::PlayerSelect);
+                                //     }
+                                // }
+
+                                // ui.add_space(normal_text_style.size / 2.0);
+                            }
+                            LanMode::Host {
+                                service_name: _,
+                                player_count: _,
+                            } => {
+                            //     ui.scope(|ui| {
+                            //         ui.set_enabled(*status != Status::Hosting);
+                            //         ui.horizontal(|ui| {
+                            //             ui.themed_label(
+                            //                 normal_text_style,
+                            //                 &params.localization.get("server-name"),
+                            //             );
+                            //             ui.add(
+                            //                 egui::TextEdit::singleline(service_name)
+                            //                     .font(normal_text_style.font_id()),
+                            //             );
+                            //             *service_name = service_name.replace(' ', "-");
+                            //         });
+                            //         ui.add_space(normal_text_style.size / 2.0);
+                            //         ui.horizontal(|ui| {
+                            //             ui.themed_label(
+                            //                 normal_text_style,
+                            //                 &params.localization.get("player-count"),
+                            //             );
+                            //             ui.add_space(normal_text_style.size);
+                            //             ui.scope(|ui| {
+                            //                 ui.set_enabled(*player_count > 2);
+                            //                 if BorderedButton::themed(small_button_style, "-")
+                            //                     .min_size(vec2(normal_text_style.size * 2.0, 0.0))
+                            //                     .show(ui)
+                            //                     .clicked()
+                            //                 {
+                            //                     *player_count = player_count
+                            //                         .saturating_sub(1)
+                            //                         .clamp(2, MAX_PLAYERS);
+                            //                 }
+                            //             });
+                            //             ui.themed_label(normal_text_style, &player_count.to_string());
+                            //             ui.scope(|ui| {
+                            //                 ui.set_enabled(*player_count < MAX_PLAYERS);
+                            //                 if BorderedButton::themed(small_button_style, "+")
+                            //           v   .min_size(vec2(normal_text_style.size * 2.0, 0.0))
+                            //                     .show(ui)
+                            //                     .clicked()
+                            //                 {
+                            //                     *player_count = player_count
+                            //                         .saturating_add(1)
+                            //                         .clamp(2, MAX_PLAYERS);
+                            //                 }
+                            //             });
+
+                            //             *service_name = service_name.replace(' ', "-");
+                            //         });
+                            //     });
+
+                            //     let (is_recreated, service_info) = lan::prepare_to_host(host_info, service_name);
+                            //     if is_recreated {
+                            //         *status = Status::Idle;
+                            //     }
+
+                            //     ui.add_space(params.game.ui_theme.font_styles.normal.size);
+
+                            //     if *status == Status::Idle {
+                            //         if BorderedButton::themed(
+                            //             small_button_style,
+                            //             &params.localization.get("start-server"),
+                            //         )
+                            //         .show(ui)
+                            //         .clicked()
+                            //         {
+                            //             *status = Status::Hosting;
+                            //             lan::start_server(service_info.clone(), *player_count);
+                            //         }
+
+                            //     // If we are hosting a match currently
+                            //     } else if *status == Status::Hosting {
+                            //         if let Some(lan_socket) = lan::wait_players(joined_players, service_info) {
+                            //             commands.insert_resource(NetworkMatchSocket(
+                            //                 Box::new(lan_socket),
+                            //             ));
+
+                            //             *status = default();
+                            // ui.ctx().set_state(MenuPage::PlayerSelect);
+                            //         }
+
+                            //         ui.horizontal(|ui| {
+                            //             if BorderedButton::themed(
+                            //                 small_button_style,
+                            //                 &params.localization.get("stop-server"),
+                            //             )
+                            //             .show(ui)
+                            //             .clicked()
+                            //             {
+                            //                 lan::stop_server(service_info);
+                            //                 *status = Status::Idle;
+                            //             }
+
+                            //             ui.themed_label(
+                            //                 normal_text_style,
+                            //                 &format!(
+                            //                     "{} {} / {}",
+                            //                     &params.localization.get("players"),
+                            //                     *joined_players + 1, // Add one to count the host.
+                            //                     player_count
+                            //                 ),
+                            //             );
+                            //         });
+                            //     }
+                            }
+                        }
+
+                        // Online game
+                        MatchKind::Online(OnlineState {
+                            player_count,
+                            matchmaking_server,
+                            mut search_state,
+                        }) => {
+                            // Get the matchmaking server from the settings.
+                            if matchmaking_server.is_empty() {
+                                *matchmaking_server =
+                                    storage
+                                    .get::<Settings>()
+                                    .unwrap_or_else(|| &meta.default_settings)
+                                    .matchmaking_server.clone();
+                            }
+
+                            ui.horizontal(|ui| {
+                                ui.set_enabled(*status == NetworkGameStatus::Idle);
+                                ui.label(
+                                    normal_text_style.rich(localization.get("player-count"))
+                                );
+
+                                ui.scope(|ui| {
+                                    ui.set_enabled(*player_count > 2);
+                                    if BorderedButton::themed(small_button_style, "-")
+                                        .min_size(vec2(normal_text_style.size * 2.0, 0.0))
+                                        .show(ui)
+                                        .clicked()
+                                    {
+                                        *player_count =
+                                            player_count.saturating_sub(1).clamp(2, MAX_PLAYERS);
+                                    }
+                                });
+                                ui.label(normal_text_style.rich(player_count.to_string()));
+                                ui.scope(|ui| {
+                                    ui.set_enabled(*player_count < MAX_PLAYERS);
+                                    if BorderedButton::themed(small_button_style, "+")
+                                        .min_size(vec2(normal_text_style.size * 2.0, 0.0))
+                                        .show(ui)
+                                        .clicked()
+                                    {
+                                        *player_count =
+                                            player_count.saturating_add(1).clamp(2, MAX_PLAYERS);
+                                    }
+                                });
+                            });
+
+                            ui.add_space(normal_text_style.size);
+
+                            if *status == NetworkGameStatus::Idle {
+                                if BorderedButton::themed(
+                                    small_button_style,
+                                    localization.get("search"),
+                                )
+                                .show(ui)
+                                .clicked()
+                                {
+                                    *status = NetworkGameStatus::Searching;
+                                    online::start_search_for_game(matchmaking_server.clone(), *player_count);
+                                }
+                            } else if *status == NetworkGameStatus::Searching {
+                                if let Some(online_socket) = online::update_search_for_game(&mut search_state) {
+                                    world.resources.insert(online_socket);
+
+                                    if search_state == SearchState::Connecting {
+                                        *status = NetworkGameStatus::default();
+                                        ui.ctx().set_state(MenuPage::PlayerSelect);
+                                    }
+                                }
+
+                                ui.horizontal(|ui| {
+                                    if BorderedButton::themed(
+                                        small_button_style,
+                                        localization.get("cancel"),
+                                    )
+                                    .show(ui)
+                                    .clicked()
+                                    {
+                                        if let Err(err) = online::stop_search_for_game() {
+                                            error!("Failed to stop searching for online game: {err}");
+                                        }
+                                        search_state = default();
+                                        *status = NetworkGameStatus::Idle;
+                                    }
+
+                                    ui.label(
+                                        smaller_text_style.rich(
+                                        match search_state {
+                                            SearchState::Connecting => {
+                                                localization.get("connecting").to_string()
+                                            }
+                                            SearchState::Searching => {
+                                                localization.get("searching").to_string()
+                                            }
+                                            SearchState::WaitingForPlayers(current) => {
+                                                localization.get(&format!(
+                                                    "waiting-for-players?current={current}&total={player_count}",
+                                                )).to_string()
+                                            }
+                                        }),
+                                    );
+                                });
+                            }
+                        }
+                    }
+
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
+                    if BorderedButton::themed(normal_button_style, localization.get("back"))
+                        .show(ui)
+                        .clicked()
+                        || player_controls.values().any(|x| x.menu_back_just_pressed)
+                    {
+                        match status {
+                            NetworkGameStatus::Idle => (),
+                            NetworkGameStatus::Searching => {
+                                if let Err(err) = online::stop_search_for_game() {
+                                    error!("Error stopping search: {:?}", err);
+                                }
+
+                                *status = NetworkGameStatus::Idle;
+                            }
+                            NetworkGameStatus::Joining => {
+                                lan::leave_server();
+                                *status = NetworkGameStatus::Idle;
+                            }
+                            NetworkGameStatus::Hosting => {
+                                *status = NetworkGameStatus::Idle;
+                                error!("Lan Stop unimplemented");
+                                // if let Some(service_info) = host_info.take() {
+                                //     lan::stop_server(&service_info);
+                                // }
+                            }
+                        }
+
+                        ui.ctx().set_state(MenuPage::Home);
+
+                    }
+             });
+
+
+            // Update state after modifications
+            ui.ctx().set_state(state);
+
+        });
+    });
+}


### PR DESCRIPTION
This adds menu + gameplay for online matches back into Jumpy. Some work left to do, but I think this is a good checkpoint, online matches work, lan is still disabled (this is up next).

TODO:
- Lan
- Cleanup menu code a bit more
- Pause menu (right now disabled, need to figure out how to do this without disabling session as I think that causes issues)


