### PR TITLE
build(steam): Steam packaging utility + linux launch scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ trace-*.json
 perf.data*
 callgrind.out*
 .cargo
+steam/packaged/**

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -48,3 +48,11 @@ Binary releases are automated via [Continuous Deployment](./.github/workflows/re
 - `jumpy-<version>-<target>.<ext>`
 
 A single archive includes the `jumpy` binary and `assets` directory. It can be verified by using a SHA256 hash file that has the same name as the artifact except it ends with ".sha256". Release artifacts are not signed at this time.
+
+### Steam
+
+This is WIP. In the `steam` folder there is a `./package_steam.sh` script. This pulls the latest github release and prepares windows/linx/apple builds as .zip files to be prepared for upload to steam. Output is in `./steam/packaged` dir. Subsequent runs cleanup built packages.
+
+To prepare packages other than latest, can be run as: `VERSION=v0.10.0 ./package_steam.sh`.
+
+This script also adds some additional launch scripts (see `./steam/launch_scripts`).

--- a/steam/launch_scripts/linux/jumpy.sh
+++ b/steam/launch_scripts/linux/jumpy.sh
@@ -29,6 +29,5 @@ if [[ $VENDOR == "Valve" ]]; then
 fi
 
 # Launch game
-DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo "Launching game without modified scaling" >> jumpy.log
 ./jumpy 2>&1 >> jumpy.log

--- a/steam/launch_scripts/linux/jumpy.sh
+++ b/steam/launch_scripts/linux/jumpy.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# If display appears to be steam deck and using native display,
+# fix text scaled too high due to bad dpi calculation: https://github.com/rust-windowing/winit/issues/2401
+
+VENDOR=$(cat "/sys/devices/virtual/dmi/id/board_vendor")
+echo "Vendor: $VENDOR" > jumpy.log
+
+if [[ $VENDOR == "Valve" ]]; then
+  # We are probably a steam deck, check if using native display:
+  xrandr >> jumpy.log
+
+  # Identify primary display
+  RESOLUTION=$(xrandr | awk '/primary/{print $4}')
+  if [ -z $RESOLUTION ]; then
+    # If single display / none tagged as primary, use thiss
+    RESOLUTION=$(xrandr | awk '/connected/{print $3}')
+  fi
+
+  echo "Resolution: $RESOLUTION" >> jumpy.log
+  if [[ "$RESOLUTION" =~ '1280x800'* ]]; then
+    echo "Launching game with WINIT_X11_SCALE_FACTOR=1 to fix scaling on steam deck display" >> jumpy.log
+    WINIT_X11_SCALE_FACTOR=1 ./jumpy 2>&1 >> jumpy.log
+    pwd >> jumpy.log
+
+    # Exit if game is closed
+    exit 0;
+  fi
+fi
+
+# Launch game
+DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo "Launching game without modified scaling" >> jumpy.log
+./jumpy 2>&1 >> jumpy.log

--- a/steam/launch_scripts/linux/jumpy_desktop.sh
+++ b/steam/launch_scripts/linux/jumpy_desktop.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+./jumpy > jumpy.log

--- a/steam/package_steam.sh
+++ b/steam/package_steam.sh
@@ -47,4 +47,3 @@ cd ..
 rm -r $RELEASE
 
 echo ".zip files in ./steam are prepared to be uploaded to steam for respective platforms."
-ls

--- a/steam/package_steam.sh
+++ b/steam/package_steam.sh
@@ -1,0 +1,50 @@
+# If Version is not set, get latest github release.
+# example: VERSION=v0.10.0
+if [ -z $VERSION ]; then
+  VERSION=$(gh release list --json name -L 1 | jq '.[0]'.name | tr -d '"')
+fi
+
+# Name of github release, also the root folder name that is inside the downloaded releases.
+RELEASE="jumpy-$VERSION"
+
+# If run in root, cd to ./steam
+FOLDER="$(basename $(pwd))"
+if [ "$FOLDER" != "steam" ]; then
+  cd steam
+fi
+
+rm -r packaged/*
+mkdir -p packaged
+
+cd packaged
+APPLE_AMD64="$RELEASE-x86_64-apple-darwin"
+gh release download $VERSION --pattern "$APPLE_AMD64.tar.gz"
+tar -xzvf  $APPLE_AMD64.tar.gz
+cd $RELEASE
+rm ../$APPLE_AMD64.tar.gz
+zip -r ../$APPLE_AMD64.zip .
+cd ..
+rm -r $RELEASE
+
+WINDOWS="$RELEASE-x86_64-pc-windows-msvc"
+gh release download $VERSION --pattern "$WINDOWS.zip"
+unzip $WINDOWS.zip
+cd $RELEASE
+rm ../$WINDOWS.zip
+zip -r ../$WINDOWS.zip .
+cd ..
+rm -r $RELEASE
+
+LINUX="$RELEASE-x86_64-unknown-linux-gnu"
+gh release download $VERSION --pattern "$LINUX.tar.gz"
+tar -xzvf  $LINUX.tar.gz
+cd $RELEASE
+cp ../../launch_scripts/linux/* .
+chmod +x
+rm ../$LINUX.tar.gz
+zip -r ../$LINUX.zip .
+cd ..
+rm -r $RELEASE
+
+echo ".zip files in ./steam are prepared to be uploaded to steam for respective platforms."
+ls


### PR DESCRIPTION
Add a steam_package.sh script that pulls releases from github, rezips as .zip such that they can be uploaded to steamworks for respective platforms.

For linux, we also install some launch scripts. There's logic here to fix #904. Isn't pretty but seems to work, scaling is correct in steam deck game mode + desktop mode. Should not impact other linux platforms. 

Need to test again with steam deck with external display, but I think this should work based on last I was exploring solutions to #904.