### PR TITLE
refactor(physics_timescale): Remove physics timestep scaled by 60 + update velocities to keep behavior

### DIFF
--- a/assets/elements/environment/crab/crab.yaml
+++ b/assets/elements/environment/crab/crab.yaml
@@ -6,8 +6,8 @@ comfortable_spawn_distance: 25.0
 comfortable_scared_distance: 100.0
 uncomfortable_respawn_time: 15s
 same_level_threshold: 50.0
-walk_speed: 0.5
-run_speed: 2.5
+walk_speed: 30.0
+run_speed: 150.0
 fps: 6
 # around about 2.5 seconds (45 fix updates per second)
 timer_delay_max: 113

--- a/assets/elements/environment/snail/snail.yaml
+++ b/assets/elements/environment/snail/snail.yaml
@@ -2,8 +2,8 @@ atlas: ./snail.atlas.yaml
 fps: 6
 body_diameter: 10
 bounciness: 0.6
-gravity: 0.5
-hit_speed: 6.0
+gravity: 1800
+hit_speed: 360.0
 hide_time: 3.0
 crawl_frames: [3, 0, 1, 2, 1, 0]
 move_frame_indexes: [1, 2, 3]

--- a/assets/elements/environment/sproinger/sproinger.yaml
+++ b/assets/elements/environment/sproinger/sproinger.yaml
@@ -2,4 +2,4 @@ atlas: ./sproinger.atlas.yaml
 sound: ./jump.ogg
 sound_volume: 0.1
 body_size: [8, 8]
-spring_velocity: 16
+spring_velocity: 960

--- a/assets/elements/environment/urchin/urchin.yaml
+++ b/assets/elements/environment/urchin/urchin.yaml
@@ -2,5 +2,5 @@ image: ./urchin.png
 body_diameter: 8.0
 bounciness: 0.6
 spin: 0.0
-gravity: 0.3
-hit_speed: 6.0
+gravity: 1200
+hit_speed: 360.0

--- a/assets/elements/item/crate/crate.yaml
+++ b/assets/elements/item/crate/crate.yaml
@@ -1,4 +1,4 @@
-throw_velocity: 10
+throw_velocity: 600
 
 atlas: ./crate.atlas.yaml
 

--- a/assets/elements/item/grenade/grenade.yaml
+++ b/assets/elements/item/grenade/grenade.yaml
@@ -1,5 +1,5 @@
 fuse_time: 4.0
-throw_velocity: 12
+throw_velocity: 720
 damage_region_size: [60, 60]
 damage_region_lifetime: 0.6
 

--- a/assets/elements/item/jellyfish/jellyfish.yaml
+++ b/assets/elements/item/jellyfish/jellyfish.yaml
@@ -1,6 +1,6 @@
 atlas: ./jellyfish.atlas.yaml
 body_size: [30, 39]
-throw_velocity: 6
+throw_velocity: 360
 angular_velocity: 0.1
 fin_anim: grab_2
 grab_offset: [0, 0]

--- a/assets/elements/item/kick_bomb/kick_bomb.yaml
+++ b/assets/elements/item/kick_bomb/kick_bomb.yaml
@@ -1,6 +1,6 @@
 fuse_time: 4s
-kick_velocity: [10, 2]
-throw_velocity: 10
+kick_velocity: [600.0, 120.0]
+throw_velocity: 600
 damage_region_size: [60, 60]
 damage_region_lifetime: 0.6
 

--- a/assets/elements/item/mine/mine.yaml
+++ b/assets/elements/item/mine/mine.yaml
@@ -1,7 +1,7 @@
 damage_region_size: [60, 60]
 damage_region_lifetime: 0.6
 arm_delay: 0.5
-throw_velocity: 9
+throw_velocity: 540
 
 atlas: ./mine.atlas.yaml
 

--- a/assets/elements/item/musket/bullet/musket.bullet.yaml
+++ b/assets/elements/item/musket/bullet/musket.bullet.yaml
@@ -1,5 +1,5 @@
 lifetime: 1.0
-speed: 10
+speed: 600
 body_diameter: 15
 atlas: ./musket_bullet.atlas.yaml
 

--- a/assets/elements/item/musket/musket.yaml
+++ b/assets/elements/item/musket/musket.yaml
@@ -18,6 +18,6 @@ can_rotate: true
 body_size: [32, 8]
 fin_anim: grab_2
 angular_velocity: 0.1
-throw_velocity: 6
+throw_velocity: 360
 grab_offset: [23, 0]
 kickback: 0

--- a/assets/elements/item/sniper_rifle/bullet/sniper.bullet.yaml
+++ b/assets/elements/item/sniper_rifle/bullet/sniper.bullet.yaml
@@ -1,5 +1,5 @@
 lifetime: 2.0
-speed: 25
+speed: 1500
 body_diameter: 7.5
 atlas: ./sniper_bullet.atlas.yaml
 

--- a/assets/elements/item/sniper_rifle/musket.yaml
+++ b/assets/elements/item/sniper_rifle/musket.yaml
@@ -18,6 +18,6 @@ can_rotate: true
 body_size: [32, 8]
 fin_anim: grab_2
 angular_velocity: 0.1
-throw_velocity: 6
+throw_velocity: 360
 grab_offset: [23, 0]
 kickback: 15

--- a/assets/elements/item/sword/sword.yaml
+++ b/assets/elements/item/sword/sword.yaml
@@ -5,9 +5,9 @@ fin_anim: grab_2
 grab_offset: [18, 26]
 body_size: [50, 8]
 # The minimum speed the sword must be moving to kill somebody
-killing_speed: 7.0
+killing_speed: 420
 angular_velocity: -0.04
 can_rotate: true
 bounciness: 0.32
-throw_velocity: 9
+throw_velocity: 540
 cooldown_frames: 22

--- a/assets/game.yaml
+++ b/assets/game.yaml
@@ -257,10 +257,10 @@ core:
     move_lerp_factor: 0.1
 
   physics:
-    terminal_velocity: 30
+    terminal_velocity: 1800
     friction_lerp: 0.85
-    stop_threshold: 1.0
-    gravity: 0.6
+    stop_threshold: 60.0
+    gravity: 2160
 
   players:
     - ./player/skins/fishy/fishy.player.yaml

--- a/assets/player/skins/fishy/fishy.player.yaml
+++ b/assets/player/skins/fishy/fishy.player.yaml
@@ -11,17 +11,17 @@ sounds:
   drop_volume: 0.05
 
 stats:
-  air_speed: 6
-  accel_air_speed: 1
-  walk_speed: 6
-  accel_walk_speed: 1
-  jump_speed: 11
-  slow_fall_speed: 1.5
-  slowdown: 0.8
+  air_speed: 360
+  accel_air_speed: 60
+  walk_speed: 360
+  accel_walk_speed: 60
+  jump_speed: 660
+  slow_fall_speed: 90
+  slowdown: 48.0
 
 body_size: [32, 48]
 slide_body_size: [48, 32]
-gravity: 0.6
+gravity: 2160
 
 layers:
   body:

--- a/assets/player/skins/orcy/orcy.player.yaml
+++ b/assets/player/skins/orcy/orcy.player.yaml
@@ -11,17 +11,17 @@ sounds:
   drop_volume: 0.05
 
 stats:
-  air_speed: 6
-  accel_air_speed: 1
-  walk_speed: 6
-  accel_walk_speed: 1
-  jump_speed: 11
-  slow_fall_speed: 1.5
-  slowdown: 0.8
+  air_speed: 360
+  accel_air_speed: 60
+  walk_speed: 360
+  accel_walk_speed: 60
+  jump_speed: 660
+  slow_fall_speed: 90
+  slowdown: 48.0
 
 body_size: [32, 48]
 slide_body_size: [48, 32]
-gravity: 0.6
+gravity: 2160
 
 layers:
   body:

--- a/assets/player/skins/pescy/pescy.player.yaml
+++ b/assets/player/skins/pescy/pescy.player.yaml
@@ -11,17 +11,17 @@ sounds:
   drop_volume: 0.05
 
 stats:
-  air_speed: 6
-  accel_air_speed: 1
-  walk_speed: 6
-  accel_walk_speed: 1
-  jump_speed: 11
-  slow_fall_speed: 1.5
-  slowdown: 0.8
+  air_speed: 360
+  accel_air_speed: 60
+  walk_speed: 360
+  accel_walk_speed: 60
+  jump_speed: 660
+  slow_fall_speed: 90
+  slowdown: 48.0
 
 body_size: [32, 48]
 slide_body_size: [48, 32]
-gravity: 0.6
+gravity: 2160
 
 layers:
   body:

--- a/assets/player/skins/sharky/sharky.player.yaml
+++ b/assets/player/skins/sharky/sharky.player.yaml
@@ -11,17 +11,17 @@ sounds:
   drop_volume: 0.05
 
 stats:
-  air_speed: 6
-  accel_air_speed: 1
-  walk_speed: 6
-  accel_walk_speed: 1
-  jump_speed: 11
-  slow_fall_speed: 1.5
-  slowdown: 0.8
+  air_speed: 360
+  accel_air_speed: 60
+  walk_speed: 360
+  accel_walk_speed: 60
+  jump_speed: 660
+  slow_fall_speed: 90
+  slowdown: 48.0
 
 body_size: [32, 48]
 slide_body_size: [48, 32]
-gravity: 0.6
+gravity: 2160
 
 layers:
   body:

--- a/packs/devpack/items/blunderbass/blunderbass.yaml
+++ b/packs/devpack/items/blunderbass/blunderbass.yaml
@@ -2,7 +2,7 @@ sprite: blunderbass.png
 bullet_sprite: bullet.png
 body_size: [32, 8]
 grab_offset: [5, -7]
-throw_velocity: 6
+throw_velocity: 360
 fin_anim: grab_2
 cooldown: 0.75
 bullet_count: 4

--- a/src/core/bullet.rs
+++ b/src/core/bullet.rs
@@ -113,6 +113,7 @@ fn update(
     invincibles: CompMut<Invincibility>,
     mut emote_regions: CompMut<EmoteRegion>,
     asset_server: Res<AssetServer>,
+    time: Res<Time>,
 ) {
     for (entity, (bullet, bullet_handle)) in entities.iter_with((&mut bullets, &bullet_handles)) {
         let bullet_meta = asset_server.get(bullet_handle.0);
@@ -132,7 +133,8 @@ fn update(
         // Move bullet
         let position = {
             let position = transforms.get_mut(entity).unwrap();
-            position.translation += (bullet.direction * *speed).extend(0.0);
+            let delta_time = time.delta_seconds();
+            position.translation += (bullet.direction * *speed * delta_time).extend(0.0);
 
             let emote_size = Vec2::new(*body_diameter * 6.0, *body_diameter * 3.5);
             emote_regions.insert(entity, EmoteRegion::basic(Emote::Alarm, emote_size, true));

--- a/src/core/elements/flappy_jellyfish.rs
+++ b/src/core/elements/flappy_jellyfish.rs
@@ -157,11 +157,11 @@ fn spawn(owner: Entity, jellyfish_ent: Entity) -> StaticSystem<(), ()> {
     .system()
 }
 
-const SPEED_X: f32 = 324.0;
-const SPEED_JUMP: f32 = 3.5;
-const GRAVITY: f32 = 0.1;
-const MIN_SPEED: Vec2 = vec2(-SPEED_X, -4.0);
-const MAX_SPEED: Vec2 = vec2(SPEED_X, 4.0);
+const SPEED_X: f32 = 19440.0;
+const SPEED_JUMP: f32 = 210.0;
+const GRAVITY: f32 = 360.0;
+const MIN_SPEED: Vec2 = vec2(-SPEED_X, -240.0);
+const MAX_SPEED: Vec2 = vec2(SPEED_X, 240.0);
 
 fn control_flappy_jellyfish(
     time: Res<Time>,

--- a/src/core/elements/sproinger.rs
+++ b/src/core/elements/sproinger.rs
@@ -135,7 +135,7 @@ fn update(
 
         for collider_ent in collision_world.actor_collisions(entity) {
             if let Some(body) = bodies.get_mut(collider_ent) {
-                if body.velocity.y < *spring_velocity - body.gravity {
+                if body.velocity.y < *spring_velocity {
                     audio_center.play_sound(*sound, *sound_volume);
                     body.velocity.y = *spring_velocity;
                     sproinger.sproinging = true;

--- a/src/core/physics.rs
+++ b/src/core/physics.rs
@@ -151,10 +151,7 @@ fn update_kinematic_bodies(
 ) {
     puffin::profile_function!();
 
-    // This value was previously using dt / (1 / crate::FPS), this was changed
-    // to no longer have FPS impact velocity, the dt * 60 is a holdover to avoid having
-    // to update all velocities.
-    let time_factor = time.delta().as_secs_f32() * 60.0;
+    let time_factor = time.delta().as_secs_f32();
 
     collision_world.update(&transforms);
     for (entity, body) in entities.iter_with(&mut bodies) {

--- a/src/core/physics.rs
+++ b/src/core/physics.rs
@@ -339,6 +339,7 @@ fn update_kinematic_bodies(
 
         if body.can_rotate {
             apply_rotation(
+                time_factor,
                 transforms.get_mut(entity).unwrap(),
                 body.velocity,
                 body.angular_velocity,
@@ -351,6 +352,7 @@ fn update_kinematic_bodies(
 
 /// Helper function to apply rotation to a kinematic body.
 fn apply_rotation(
+    delta_time: f32,
     transform: &mut Transform,
     velocity: Vec2,
     angular_velocity: f32,
@@ -366,7 +368,7 @@ fn apply_rotation(
             angle += velocity.x.abs() * angular_velocity;
         }
     } else {
-        angle += (angular_velocity * FPS).to_radians();
+        angle += (angular_velocity * delta_time).to_radians();
     }
 
     transform.rotation = Quat::from_rotation_z(angle);

--- a/src/core/physics.rs
+++ b/src/core/physics.rs
@@ -327,7 +327,7 @@ fn update_kinematic_bodies(
                 body.velocity.y *= meta.core.physics.friction_lerp;
             }
 
-            if body.velocity.y <= meta.core.physics.gravity {
+            if body.velocity.y <= body.gravity * time_factor {
                 body.velocity.y = 0.0;
             }
         }

--- a/src/core/player.rs
+++ b/src/core/player.rs
@@ -741,7 +741,7 @@ fn hydrate_players(
                         sync_animation: false,
                     },
                 );
-                item_throws.insert(hat_ent, ItemThrow::strength(7.0));
+                item_throws.insert(hat_ent, ItemThrow::strength(420.0));
                 Some(hat_ent)
             } else {
                 to_kill.push(hat_ent);


### PR DESCRIPTION
**Overview:**
Delta time in physics update previously had a scale of 60 due to a prior fix regarding timestep.

This change removes the scaling of physics timestep by 60, and adjusts velocities / forces (gravity) to account for this so behavior does not change.

**Impact:**  Will help with ragdoll work I am doing, velocity metadata can be used with objects simulated in rapier and on our kinematics without having to get messy scaling them back and forth, or dealing with a very large timestep in rapier (which did not go well in my experiments).

units of velocity and gravity now relate more intuitively to position + sizes of objects in terms of setting velocity based on how far a contributor may want something to move per second.

**Changes:**
- velocities all scaled up by 60, gravity scaled up by 3600 (60*60) as this is multiplied by time twice.
  - Gravity values are now quite large, unless we want to change unit of gravity and add back in a magic scale factor will have to roll with this I guess. I think it's ok this way, new contributors may reference global gravity metadata to get an idea of what to set a specific body's gravity to.
- apply_rotation now uses delta time (kinematic rotations should now be consistent regardless of frame rate)
- Fix bullet position update from velocity not being scaled by delta time
- Fix setting velocity.y = 0 when grounded comparing against global gravity (now corrected to use body's gravity)
- Fix sproinger velocity condition including gravity incorrectly (don't think we need gravity in this at all)

**Other Notes:**
I am hoping I caught all of the values that needed updating. Testing movement / jump, throwing items, sproinger, bomb bounces, it looks right to me.
- One thing I noticed is that some item metadata includes a "angular_velocity" value which is used as spin factor for item throw. Spin scales based on the throw velocity, so these spin values do not need to be updated. This is more of a spin factor than a true angular velocity, may consider renaming in future.
- There are a few values hard coded that we could pull into metadata, but I didn't want to make footprint of change any larger than necessary.
- some metadata for player movement is duplicated between player skin metadata, may want to pull this out to single metadata location in future.