### PR TITLE
feat(physics): Support Dynamic bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3602,17 +3602,6 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
@@ -3813,7 +3802,7 @@ dependencies = [
  "jni",
  "ndk 0.8.0",
  "ndk-context",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
  "oboe-sys",
 ]
@@ -3957,7 +3946,7 @@ dependencies = [
  "either",
  "indexmap 1.9.3",
  "nalgebra",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
  "rustc-hash",
  "simba",
@@ -4451,9 +4440,8 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "rapier2d"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94d294a9b96694c14888dd0e8ce77620dcc4f2f49264109ef835fa5e2285b84"
+version = "0.18.0"
+source = "git+https://github.com/MaxCWhitehead/rapier?branch=fix-dynamic-change#6eed9a53a58e33263f1b9cf7bb41f6c443966c35"
 dependencies = [
  "approx",
  "arrayvec",
@@ -4461,9 +4449,8 @@ dependencies = [
  "bitflags 1.3.2",
  "crossbeam",
  "downcast-rs",
- "indexmap 1.9.3",
  "nalgebra",
- "num-derive 0.3.3",
+ "num-derive",
  "num-traits",
  "parry2d",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tracing             = "0.1.37"
 puffin              = { version = "0.17.0", features = ["web"] }
 puffin_egui         = "0.23.0"
 petgraph            = "0.6.4"
-rapier2d            = { version = "0.17.2", features = ["debug-render", "enhanced-determinism"] }
+rapier2d            = { git = "https://github.com/MaxCWhitehead/rapier", branch = "fix-dynamic-change", features = ["debug-render", "enhanced-determinism"] }
 indexmap            = "2.0.0"
 serde               = { version = "1.0.188", features = ["derive"] }
 shiftnanigans       = "0.3.3"

--- a/src/core/debug.rs
+++ b/src/core/debug.rs
@@ -52,7 +52,8 @@ impl<'a> rapier::DebugRenderBackend for RapierDebugBackend<'a> {
             rapier::DebugRenderObject::Collider(_, collider) => collider.is_enabled(),
             rapier::DebugRenderObject::ImpulseJoint(_, _) => true,
             rapier::DebugRenderObject::MultibodyJoint(_, _, _) => true,
-            rapier::DebugRenderObject::Other => true,
+            rapier::DebugRenderObject::ColliderAabb(_, _, _) => true,
+            rapier::DebugRenderObject::ContactPair(_, _, _) => true,
         };
         if render {
             self.points.push(vec2(a.x, a.y));

--- a/src/core/debug.rs
+++ b/src/core/debug.rs
@@ -95,6 +95,7 @@ fn debug_render_colliders(
     settings: ResInit<DebugSettings>,
     mut collision_world: CollisionWorld,
     transforms: Comp<Transform>,
+    mut dynamic_bodies: CompMut<DynamicBody>,
     mut paths: CompMut<Path2d>,
     mut debug_context: ResMutInit<RapierDebugContext>,
 ) {
@@ -102,7 +103,7 @@ fn debug_render_colliders(
         // TODO: It's unfortunate that we are doing an extra sync here, just for debug rendering. We
         // should try find a way to avoid this. Without this, the collider body positions will be
         // out of sync when they are rendered.
-        collision_world.update(&transforms);
+        collision_world.sync_bodies(&transforms, &mut dynamic_bodies);
 
         let mut points = Vec::new();
         let mut line_breaks = Vec::new();

--- a/src/core/physics/dynamic_body.rs
+++ b/src/core/physics/dynamic_body.rs
@@ -1,0 +1,101 @@
+//! DynamicBody component allows simultaing phyiscs of a body.
+
+use std::sync::Mutex;
+
+use crate::prelude::*;
+
+pub type SimulationCommand = dyn FnOnce(&mut rapier::RigidBody) + 'static + Send;
+
+/// Bodies with `DynamicBody` will be simulated dynamically
+/// if `is_dynamic` is True. Currently `DynamicBody` requires component
+/// [`KinematicBody`], as it shares shape.
+///
+/// `if is_dynamic` is false, body is treated as kinematic.
+#[derive(Default, Clone, HasSchema)]
+#[repr(C)]
+pub struct DynamicBody {
+    /// Is body simulating or kinematic mode?
+    pub is_dynamic: bool,
+
+    /// This transform is used to determine if position has moved in gameplay code outside of rapier sim.
+    /// Is only relevant when `is_dynamic` = true. It is updated whenever transform is synced to or from rapier.
+    ///
+    /// If this does not match entity `Transform` at beginning of physics update, rapier simulation body
+    /// will be teleported to match gameplay.
+    ///
+    /// See [`Self::simulation_transform_needs_update`] for context.
+    last_rapier_synced_transform: Transform,
+
+    /// Simulation command queue. See [`Self::push_simulation_command`] for details.
+    #[schema(opaque)]
+    command_queue: Arc<Mutex<Vec<Box<SimulationCommand>>>>,
+}
+
+impl DynamicBody {
+    /// Create new `DynamicBody`. is_dynamic = true simulates physics, false remains kinematic.
+    pub fn new(is_dynamic: bool) -> Self {
+        Self {
+            is_dynamic,
+            ..Default::default()
+        }
+    }
+    /// Check if rapier simulation's body's transform is dirty (If it was modified outside of
+    /// physics simulation). Always returns true if object is not simulating.
+    ///
+    /// Updates `last_rapier_synced_transform` if called, should only be called before updating rapier positions from gameplay.
+    pub fn simulation_transform_needs_update(&mut self, transform: &Transform) -> bool {
+        if !self.is_dynamic {
+            // Body not simulating, we should always update transform in sim
+            return true;
+        }
+
+        // Only use 2D translation + rotation, as this is what rapier sim uses.
+        let last_translation = self.last_rapier_synced_transform.translation.xy();
+        let current_translation = transform.translation.xy();
+        let last_rotation = self
+            .last_rapier_synced_transform
+            .rotation
+            .to_euler(EulerRot::XYZ)
+            .2;
+        let current_rotation = transform.rotation.to_euler(EulerRot::XYZ).2;
+
+        // transform was modified in gameplay outside of rapier sim
+        if last_translation != current_translation || last_rotation != current_rotation {
+            self.last_rapier_synced_transform.translation = transform.translation;
+            self.last_rapier_synced_transform.rotation = transform.rotation;
+
+            return true;
+        }
+
+        // Transform was not modified outside of rapier sim, is not dirty
+        false
+    }
+
+    /// Update `last_rapier_synced_transform` from simulation output so we can determine when gameplay has modified transform
+    /// outside of rapier for [`Self::simulation_transform_needs_update`].
+    ///
+    /// This does NOT update position of entity.
+    pub fn update_last_rapier_synced_transform(&mut self, translation: Vec3, rotation: Quat) {
+        self.last_rapier_synced_transform.translation = translation;
+        self.last_rapier_synced_transform.rotation = rotation;
+    }
+
+    /// Push command that is executed before next physics step, after body is guranteed to be initialized in rapier
+    /// and set to [`rapier::RigidBodyType::Dynamic`] (if transitioning from Kinematic to Dynamic).
+    ///
+    /// Commands are only executed if `is_dynamic` = true (body is simulating) next frame! Otherwise they are discarded.
+    /// This restriction is in place to prevent switching back to kinematic and modifying simulation state in an unintentional way.
+    ///
+    /// Commands are executed in order they are pushed. If you need to immediately apply changes, use [`CollisionWorld::mutate_rigidbody`].
+    pub fn push_simulation_command(&mut self, command: Box<SimulationCommand>) {
+        self.command_queue.lock().unwrap().push(command);
+    }
+
+    /// Retrieve [`SimulationCommand`] queue for processing. Values are moved out of self, flushing queue.
+    pub fn simulation_commands(&mut self) -> Vec<Box<SimulationCommand>> {
+        let mut dummy: Vec<Box<SimulationCommand>> = vec![];
+        let mut queue = self.command_queue.lock().unwrap();
+        std::mem::swap(&mut *queue, &mut dummy);
+        dummy
+    }
+}


### PR DESCRIPTION
This is the base of core changes to support ragdolls, allows us to simulate dynamic bodies in rapier.

DynamicBody component may be added to an entity that has KinematicBody, and if enabled, body will simulate physics. Transitioning between kinematic / dynamic and adjusting rapier data + collider is handled on next physics update.

This change should have no impact on existing kinematics, scene queries, etc. Usage of these changes will come in other PR soon.

**Switched to fork of rapier (temporarily hopefully):**
I switched us to a fork of rapier to fix a bug in which changing a rapier rigidbody from kinematic to dynamic will not put it in active dynamic set, so gravity is not applied. It seems they rely on contact graph to add body to this set, but if not in contact with anything it breaks. I have a PR open for a fix in rapier.
- I also updated version, slight change in debug draw code is because of changes there.

**Some notes on changes:**
- Some helper functions are included for pushing simulation commands for dynamic body that apply changes to rapier body before next physics step.
- There is a mutate_rigidbody function on CollisionWorld that makes accessing rapier body for immediate mutation slightly more convenient.
- Previously bodies were created as dynamic (but we used them as kinematic anyway), now they are actually flagged as kinematic in rapier. This does not impact collision events at all.

There's a decent chunk of physics stuff in collision module now, at some point maybe should detangle this, but probably fine for now. I renamed some functions to make things more clear.


