### PR TITLE
feat(physics): Contact filtering + changing shape + jump through for simulated bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3019,6 +3019,7 @@ dependencies = [
  "bevy_dylib",
  "bevy_tasks",
  "bitfield",
+ "bitflags 2.4.2",
  "bones_bevy_renderer",
  "bones_framework",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 bones_framework     = { git = "https://github.com/fishfolk/bones" }
 bones_bevy_renderer = { git = "https://github.com/fishfolk/bones" }
 bevy_tasks          = "0.11"
+bitflags            = "2.4"
 turborand           = { version = "0.10.0", features = ["atomic"] }
 tracing             = "0.1.37"
 puffin              = { version = "0.17.0", features = ["web"] }

--- a/src/core/physics/collisions/filtering.rs
+++ b/src/core/physics/collisions/filtering.rs
@@ -1,9 +1,4 @@
 use bitflags::bitflags;
-// pub enum CollisionGroupEnum {
-//     NONE: u32 = 32,
-//     SOLID = 0b0001,
-//     ALL = u32::MAX,
-// }
 
 bitflags! {
 /// Flags for collision filtering, this is used for collision events.

--- a/src/core/physics/collisions/filtering.rs
+++ b/src/core/physics/collisions/filtering.rs
@@ -1,0 +1,35 @@
+use bitflags::bitflags;
+// pub enum CollisionGroupEnum {
+//     NONE: u32 = 32,
+//     SOLID = 0b0001,
+//     ALL = u32::MAX,
+// }
+
+bitflags! {
+/// Flags for collision filtering, this is used for collision events.
+pub struct CollisionGroup: u32 {
+    // May not detect colliions
+    const NONE = 0b0000;
+    /// Default membership for bodies
+    const DEFAULT= 0b0001;
+    // All CollisionGroups are on body / or filtered for body
+    const ALL = u32::MAX;
+}
+}
+
+bitflags! {
+/// Flags for filtering simulated collision for dynamics.
+/// First [`CollisionGroup`] filters intersection, and then
+/// if `SimulationGroup` flags do not intersect, collision event is generated,
+/// but not contact forces.
+pub struct SolverGroup: u32 {
+    const NONE = 0b0000;
+    // Solid world geometry like tiles go in this group
+    const SOLID_WORLD = 0b0001;
+    // Jump through world geometry. (Contacts will be modified so simulated objects only collide from above).
+    const JUMP_THROUGH = 0b0010;
+    // Dynamic bodies go in this group
+    const DYNAMIC = 0b0100;
+    const ALL = u32::MAX;
+}
+}


### PR DESCRIPTION
Another chunk of features implemented to support ragdolls + dynamic bodies in Jumpy.

### **Contact filtering:**
Add bit flags for rapier `CollisionGroup` and `SolverGroup`.
- The Collision group filters both contact forces and events, these are configured such that there is no change here in collision events.
- Solver group then filters contact forces, this is used to make sure dynamic actors only simulate collision with tiles (solid + jump through) and solids, not other kinematic (or dynamic) actors.

### **Jump Through for Dynamics:**
Dynamics collide with jump through tiles. A contact modification physics hook is implemented so dynamics moving upward through jump throughs have contact thrown out, and kept when falling.
- Only the contact filtering `PhysicsHook` is used, and is only enable on dynamic bodies while they are simulating.

### **Changing actor shape:**
I found that using a capsule works better for player ragdoll then rectangle, which requires being able to change the shape of a collider. A helper function is added to do this correctly, changing shape is only currently supported for actors. 

### **Handling `Stop` collision events for removed colliders:**
Changing an actor's shape involves removing collider and re-adding it. This triggers a stop event from rapier. These events provide collider handles, yet we map this to entities from userdata. The consequence of this is that when the stop event is dispatched, the collider handle is already invalid (generation incremented), meaning we no longer can access user data to determine what entity should be removed.
- We now have a function that should be called on removal of collider in `CollisionCache` that temporarily caches the handle + entity, which is used as fallback when receiving stop event if collider handle is not valid.

This is not a great system, if someone removes a collider and does not call this, our collision event will not be removed causing bugs. Might be able to make this better, but for now will just have to make sure if we get fancy removing a collider (which is already a delicate / involved operation) this is called. The function to change actor shape calls this for us.