### PR TITLE
feat(physics): Add extra colliders to jump_through tiles for collision with dynamics

### DIFF
--- a/assets/map/resources/ship_decorations.atlas.yaml
+++ b/assets/map/resources/ship_decorations.atlas.yaml
@@ -2,3 +2,25 @@ image: ./ship_decorations.png
 tile_size: [32, 32]
 columns: 11
 rows: 5
+tile_collision:
+  41:
+    min:
+    - 0.2
+    - 0.75
+    max:
+    - 1.0
+    - 1.0
+  42:
+    min:
+    - 0.0
+    - 0.75
+    max:
+    - 1.0
+    - 1.0
+  43:
+    min:
+    - 0.0
+    - 0.75
+    max:
+    - 0.8
+    - 1.0

--- a/src/core/physics/collisions/filtering.rs
+++ b/src/core/physics/collisions/filtering.rs
@@ -17,6 +17,7 @@ bitflags! {
 /// First [`CollisionGroup`] filters intersection, and then
 /// if `SimulationGroup` flags do not intersect, collision event is generated,
 /// but not contact forces.
+#[derive(Copy, Clone)]
 pub struct SolverGroup: u32 {
     const NONE = 0b0000;
     // Solid world geometry like tiles go in this group


### PR DESCRIPTION
define some collision info for jump through wood tiles, used to create accurate colliders for collision with ragdoll / dynamics.

The standard tile is still there for all intents and purposes. If there is an extra collider defined, this collider is also added, and is set to solver group such that dynamics will collider with it.
- This additional collider is not used for collision events.
- if additional collider is present, original tile collider no longer has solver group for collisions.

This fixes dynamics colliding with the invisible chunk on thin tiles such as jump through wood.

I think we're done with the trickle of auxiliary features and next PR should be ragdolls 😆 