### PR TITLE
feat(ragdoll): Add player ragdoll state + corpse physics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "bones_asset"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "bones_bevy_renderer"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "anyhow",
  "atomicell",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "bones_framework"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "bones_lib"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "bones_ecs",
  "instant",
@@ -1240,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "bones_matchmaker_proto"
 version = "0.2.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "serde",
 ]
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "bones_schema"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "append-only-vec",
  "bones_schema_macros",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "bones_schema_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1276,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "bones_scripting"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "async-channel",
  "bevy_tasks",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "bones_utils"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "bones_utils_macros",
  "branches",
@@ -1314,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "bones_utils_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "quote",
  "venial",
@@ -2951,15 +2951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4321,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "quinn_runtime_bevy"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ca6a99caa1d3f2c511a25bc46cc95dc052d18c2d"
 dependencies = [
  "async-executor",
  "async-io",
@@ -4948,7 +4939,7 @@ checksum = "9635466532d454fa020acbb12f629f1fc02fc9b4d5b39cc72ca478be37e314bc"
 dependencies = [
  "bitvec",
  "fastrand 1.9.0",
- "itertools 0.10.5",
+ "itertools",
  "log",
  "nohash-hasher",
 ]

--- a/assets/game.yaml
+++ b/assets/game.yaml
@@ -264,6 +264,12 @@ core:
     friction_lerp: 0.85
     stop_threshold: 60.0
     gravity: 2160
+    player:
+      ragdoll_initial_pop: 200
+      ragdoll_initial_ang_vel: 2
+      ragdoll_twitch_vel: 50
+      ragdoll_twitch_delay: 0.15
+      ragdoll_additional_mass: 300
 
   players:
     - ./player/skins/fishy/fishy.player.yaml

--- a/assets/game.yaml
+++ b/assets/game.yaml
@@ -45,6 +45,7 @@ default_settings:
       shoot: !Button West
       slide: !Button North
       pause: !Button Start
+      ragdoll: !Button RightTrigger
       menu_back: !Button East
       menu_start: !Button Start
       menu_confirm: !Button South
@@ -60,6 +61,7 @@ default_settings:
       grab: !Keyboard V
       shoot: !Keyboard C
       slide: !Keyboard B
+      ragdoll: !Keyboard F
       pause: !Keyboard Escape
       menu_back: !Keyboard Escape
       menu_start: !Keyboard Return
@@ -76,6 +78,7 @@ default_settings:
       grab: !Keyboard ShiftRight
       shoot: !Keyboard Period
       slide: !Keyboard Slash
+      ragdoll: !Keyboard M
       menu_confirm: !Keyboard Comma
       menu_back: !Keyboard ShiftRight
 

--- a/assets/locales/en-US/controls.ftl
+++ b/assets/locales/en-US/controls.ftl
@@ -6,6 +6,7 @@ jump = Jump
 grab-drop = Grab / Drop
 shoot = Shoot
 slide = Slide
+ragdoll = Ragdoll
 menu-confirm = Menu Confirm
 menu-back = Menu Back
 menu-start = Menu Start

--- a/assets/player/skins/fishy/fishy.player.yaml
+++ b/assets/player/skins/fishy/fishy.player.yaml
@@ -133,6 +133,12 @@ layers:
           - idx: 90
         fps: *fps
         repeat: false
+      death_ragdoll:
+        frames:
+          - idx: 56
+            offset: [0, -4]
+        fps: *fps
+        repeat: false
   fin:
     atlas: ./fishy-fin.atlas.yaml
     offset: [-14, 3]
@@ -194,6 +200,10 @@ layers:
         fps: *fps
         frames:
           - 3 # Intentionally an invisible frame
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - 20
       grab_1:
         fps: *fps
         frames:
@@ -258,6 +268,10 @@ layers:
         fps: *fps
         frames:
           - 10 # Intentionally an invisible frame
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - 5
       emote_alarm:
         fps: *fps
         frames:

--- a/assets/player/skins/fishy/fishy.player.yaml
+++ b/assets/player/skins/fishy/fishy.player.yaml
@@ -93,6 +93,17 @@ layers:
             offset: [0, -4]
         fps: *fps
         repeat: false
+      ragdoll:
+        fps: *fps
+        frames:
+          - idx: 28
+            offset: [0, 3]
+        repeat: false
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - idx: 42
+            offset: [0, 3]
       slide:
         fps: *fps
         frames:
@@ -163,6 +174,14 @@ layers:
         fps: *fps
         frames:
           - 20
+      ragdoll:
+        fps: *fps
+        frames:
+          - 10
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - 15
       slide:
         fps: *fps
         frames:
@@ -219,6 +238,14 @@ layers:
         fps: *fps
         frames:
           - 5
+      ragdoll:
+        fps: *fps
+        frames:
+          - 9
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - 4
       slide:
         fps: *fps
         frames:

--- a/assets/player/skins/orcy/orcy.player.yaml
+++ b/assets/player/skins/orcy/orcy.player.yaml
@@ -133,6 +133,11 @@ layers:
           - idx: 90
         fps: *fps
         repeat: false
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - idx: 56
+            offset: [0, -4]
   fin:
     atlas: ./orcy-fin.atlas.yaml
     offset: [-14, 3]
@@ -194,6 +199,9 @@ layers:
         fps: *fps
         frames:
           - 3 # Intentionally an invisible frame
+      death_ragdoll:
+        frames:
+          - 20
       grab_1:
         fps: *fps
         frames:
@@ -260,6 +268,10 @@ layers:
         fps: *fps
         frames:
           - 8 # Intentionally an invisible frame
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - 5
       emote_alarm:
         fps: *fps
         frames:

--- a/assets/player/skins/orcy/orcy.player.yaml
+++ b/assets/player/skins/orcy/orcy.player.yaml
@@ -93,6 +93,17 @@ layers:
             offset: [0, -4]
         fps: *fps
         repeat: false
+      ragdoll:
+        fps: *fps
+        frames:
+          - idx: 28
+            offset: [0, 3]
+        repeat: false
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - idx: 42
+            offset: [0, 3]
       slide:
         fps: *fps
         frames:
@@ -163,6 +174,14 @@ layers:
         fps: *fps
         frames:
           - 20
+      ragdoll:
+        fps: *fps
+        frames:
+          - 10
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - 15
       slide:
         fps: *fps
         frames:
@@ -225,6 +244,14 @@ layers:
         fps: *fps
         frames:
           - 8 # Intentionally an invisible frame
+      ragdoll:
+        fps: *fps
+        frames:
+          - 7
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - 4
       death_spine:
         fps: *fps
         frames:

--- a/assets/player/skins/pescy/pescy.player.yaml
+++ b/assets/player/skins/pescy/pescy.player.yaml
@@ -93,6 +93,17 @@ layers:
             offset: [0, -4]
         fps: *fps
         repeat: false
+      ragdoll:
+        fps: *fps
+        frames:
+          - idx: 28
+            offset: [0, 3]
+        repeat: false
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - idx: 42
+            offset: [0, 3]
       slide:
         fps: *fps
         frames:
@@ -163,6 +174,14 @@ layers:
         fps: *fps
         frames:
           - 20
+      ragdoll:
+        fps: *fps
+        frames:
+          - 15
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - 15
       slide:
         fps: *fps
         frames:
@@ -225,6 +244,14 @@ layers:
         fps: *fps
         frames:
           - 8 # Intentionally an invisible frame
+      ragdoll:
+        fps: *fps
+        frames:
+          - 5
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - 4
       death_spine:
         fps: *fps
         frames:

--- a/assets/player/skins/pescy/pescy.player.yaml
+++ b/assets/player/skins/pescy/pescy.player.yaml
@@ -133,6 +133,11 @@ layers:
           - idx: 90
         fps: *fps
         repeat: false
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - idx: 56
+            offset: [0, -4]
   fin:
     atlas: ./pescy-fin.atlas.yaml
     offset: [-14, 3]
@@ -194,6 +199,10 @@ layers:
         fps: *fps
         frames:
           - 3 # Intentionally an invisible frame
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - 20
       grab_1:
         fps: *fps
         frames:
@@ -260,6 +269,10 @@ layers:
         fps: *fps
         frames:
           - 8 # Intentionally an invisible frame
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - 5
       emote_alarm:
         fps: *fps
         frames:

--- a/assets/player/skins/sharky/sharky.player.yaml
+++ b/assets/player/skins/sharky/sharky.player.yaml
@@ -93,6 +93,17 @@ layers:
             offset: [0, -4]
         fps: *fps
         repeat: false
+      ragdoll:
+        fps: *fps
+        frames:
+          - idx: 28
+            offset: [0, 3]
+        repeat: false
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - idx: 42
+            offset: [0, 3]
       slide:
         fps: *fps
         frames:
@@ -163,6 +174,14 @@ layers:
         fps: *fps
         frames:
           - 20
+      ragdoll:
+        fps: *fps
+        frames:
+          - 10
+      ragdoll_twitch:
+        fps: *fps
+        frames:
+          - 15
       slide:
         fps: *fps
         frames:
@@ -218,6 +237,14 @@ layers:
         frames:
           - 2
       crouch:
+        fps: *fps
+        frames:
+          - 4
+      ragdoll:
+        fps: *fps
+        frames:
+          - 7
+      ragdoll_twitch:
         fps: *fps
         frames:
           - 4

--- a/assets/player/skins/sharky/sharky.player.yaml
+++ b/assets/player/skins/sharky/sharky.player.yaml
@@ -133,6 +133,11 @@ layers:
           - idx: 90
         fps: *fps
         repeat: false
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - idx: 56
+            offset: [0, -4]
   fin:
     atlas: ./sharky-fin.atlas.yaml
     offset: [-14, 3]
@@ -194,6 +199,10 @@ layers:
         fps: *fps
         frames:
           - 3 # Intentionally an invisible frame
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - 20
       grab_1:
         fps: *fps
         frames:
@@ -260,6 +269,10 @@ layers:
         fps: *fps
         frames:
           - 8 # Intentionally an invisible frame
+      death_ragdoll:
+        fps: *fps
+        frames:
+          - 5
       emote_alarm:
         fps: *fps
         frames:

--- a/src/core/attachment.rs
+++ b/src/core/attachment.rs
@@ -112,6 +112,9 @@ pub fn update_attachments(
             }
         }
 
+        // Apply parent rotation to offset. Currently scale is not applied (but probably should be.)
+        offset = attached_transform.rotation * offset;
+
         transform.translation += offset;
     }
 }

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -83,6 +83,18 @@ pub struct PhysicsMeta {
     pub terminal_velocity: f32,
     pub friction_lerp: f32,
     pub stop_threshold: f32,
+    pub player: PhysicsPlayerMeta,
+}
+
+#[derive(HasSchema, Clone, Debug, Default)]
+#[repr(C)]
+pub struct PhysicsPlayerMeta {
+    pub ragdoll_initial_pop: f32,
+    pub ragdoll_initial_ang_vel: f32,
+    pub ragdoll_twitch_vel: f32,
+    pub ragdoll_twitch_delay: f32,
+    // Add additional mass to ragdoll body
+    pub ragdoll_additional_mass: f32,
 }
 
 #[derive(HasSchema, Deserialize, Clone, Debug, Default)]

--- a/src/core/physics/collisions.rs
+++ b/src/core/physics/collisions.rs
@@ -770,7 +770,6 @@ impl<'a> CollisionWorld<'a> {
                 );
             }
             rapier_collider.set_enabled(!collider.disabled);
-            rapier_collider.set_position_wrt_parent(rapier::Isometry::new(default(), 0.0));
         }
 
         for (solid_ent, solid) in self.entities.iter_with(&mut self.solids) {

--- a/src/core/player.rs
+++ b/src/core/player.rs
@@ -550,6 +550,13 @@ struct PlayersHaveSpawned {
 #[derive(Debug, Clone, HasSchema, Default)]
 struct Hat(Handle<HatMeta>);
 
+/// Build `ColliderShape` for player from `PlayerMeta`.
+pub fn player_collider_shape(meta: &PlayerMeta) -> ColliderShape {
+    ColliderShape::Rectangle {
+        size: meta.body_size,
+    }
+}
+
 fn hydrate_players(
     mut commands: Commands,
     mut entities: ResMutInit<Entities>,
@@ -627,9 +634,7 @@ fn hydrate_players(
         kinematic_bodies.insert(
             player_entity,
             KinematicBody {
-                shape: ColliderShape::Rectangle {
-                    size: meta.body_size,
-                },
+                shape: player_collider_shape(&meta),
                 has_mass: true,
                 has_friction: false,
                 gravity: meta.gravity,

--- a/src/core/player/state.rs
+++ b/src/core/player/state.rs
@@ -52,6 +52,7 @@ pub fn plugin(session: &mut Session) {
     drive_jellyfish::install(session);
     idle::install(session);
     incapacitated::install(session);
+    ragdoll::install(session);
     midair::install(session);
     walk::install(session);
 }

--- a/src/core/player/state/states.rs
+++ b/src/core/player/state/states.rs
@@ -7,4 +7,5 @@ pub mod drive_jellyfish;
 pub mod idle;
 pub mod incapacitated;
 pub mod midair;
+pub mod ragdoll;
 pub mod walk;

--- a/src/core/player/state/states/crouch.rs
+++ b/src/core/player/state/states/crouch.rs
@@ -47,7 +47,9 @@ pub fn player_state_transition(
         }
         let control = &player_inputs.players[player_idx.0 as usize].control;
 
-        if !body.is_on_ground || control.move_direction.y > -0.5 {
+        if control.ragdoll_just_pressed {
+            state.current = *ragdoll::ID;
+        } else if !body.is_on_ground || control.move_direction.y > -0.5 {
             state.current = *idle::ID;
         }
     }

--- a/src/core/player/state/states/dead.rs
+++ b/src/core/player/state/states/dead.rs
@@ -20,26 +20,35 @@ pub fn player_state_transition(
 pub fn handle_player_state(
     entities: Res<Entities>,
     mut commands: Commands,
+    assets: Res<AssetServer>,
+    player_indices: Comp<PlayerIdx>,
+    player_inputs: Res<MatchInputs>,
     player_states: Comp<PlayerState>,
     killed_players: Comp<PlayerKilled>,
-    sprites: Comp<AtlasSprite>,
-    transform: Comp<Transform>,
+    _sprites: Comp<AtlasSprite>,
+    _transform: Comp<Transform>,
     player_layers: Comp<PlayerLayers>,
     mut player_body_attachments: CompMut<PlayerBodyAttachment>,
     mut kinematic_bodies: CompMut<KinematicBody>,
+    mut dynamic_bodies: CompMut<DynamicBody>,
     mut animations: CompMut<AnimationBankSprite>,
+    game_meta: Root<GameMeta>,
+    mut collision_world: CollisionWorld,
 ) {
-    for (player_ent, (state, animation, killed_player)) in
-        entities.iter_with((&player_states, &mut animations, &killed_players))
-    {
+    for (player_ent, (state, animation, _killed_player, player_idx)) in entities.iter_with((
+        &player_states,
+        &mut animations,
+        &killed_players,
+        &player_indices,
+    )) {
         if state.current != *ID {
             continue;
         };
 
         if state.age == 0 {
-            let sprite = sprites.get(player_ent).unwrap();
-            let player_on_right = !sprite.flip_x;
-            let transform = transform.get(player_ent).unwrap();
+            // let sprite = sprites.get(player_ent).unwrap();
+            // let player_on_right = !sprite.flip_x;
+            // let transform = transform.get(player_ent).unwrap();
             let layers = player_layers.get(player_ent).unwrap();
 
             // Knock the player's hat off if they had one.
@@ -48,17 +57,47 @@ pub fn handle_player_state(
                 kinematic_bodies.get_mut(hat_ent).unwrap().is_deactivated = false;
             }
 
-            animation.current = match killed_player.hit_from {
-                Some(hit_from)
-                    if {
-                        let is_hit_right = transform.translation.x < hit_from.x;
-                        (player_on_right && is_hit_right) || (!player_on_right && !is_hit_right)
-                    } =>
-                {
-                    "death_spine".into()
-                }
-                _ => "death_belly".into(),
-            };
+            if !dynamic_bodies.contains(player_ent) {
+                let dynamic_body = DynamicBody::new(true);
+                dynamic_bodies.insert(player_ent, dynamic_body);
+            } else {
+                dynamic_bodies.get_mut(player_ent).unwrap().is_dynamic = true;
+            }
+
+            let player_physics = &game_meta.core.physics.player;
+            let dynamic = dynamic_bodies.get_mut(player_ent).unwrap();
+            let pop_vel = Vec2::new(0.0, player_physics.ragdoll_initial_pop);
+            let ang_vel = player_physics.ragdoll_initial_ang_vel;
+            let current_vel = kinematic_bodies.get_mut(player_ent).unwrap().velocity;
+            dynamic.push_simulation_command(Box::new(move |body: &mut rapier::RigidBody| {
+                let mass = body.mass();
+                body.set_linvel(current_vel.into(), true);
+
+                // apply initial impulse
+                body.apply_impulse((pop_vel * mass).into(), true);
+                body.apply_torque_impulse(
+                    ang_vel * body.mass_properties().effective_angular_inertia(),
+                    true,
+                )
+            }));
+
+            let player_meta_handle = player_inputs.players[player_idx.0 as usize].selected_player;
+            let player_meta = &*assets.get(player_meta_handle);
+            ragdoll::use_ragdoll_collider(player_ent, player_meta, &mut collision_world);
+
+            // animation.current = match killed_player.hit_from {
+            //     Some(hit_from)
+            //         if {
+            //             let is_hit_right = transform.translation.x < hit_from.x;
+            //             (player_on_right && is_hit_right) || (!player_on_right && !is_hit_right)
+            //         } =>
+            //     {
+            //         "death_spine".into()
+            //     }
+            //     _ => "death_belly".into(),
+            // };
+
+            animation.current = "death_ragdoll".into();
         }
 
         if state.age >= 80 {

--- a/src/core/player/state/states/idle.rs
+++ b/src/core/player/state/states/idle.rs
@@ -24,7 +24,9 @@ pub fn player_state_transition(
 
         let control = &player_inputs.players[player_idx.0 as usize].control;
 
-        if !body.is_on_ground {
+        if control.ragdoll_just_pressed {
+            player_state.current = *ragdoll::ID;
+        } else if !body.is_on_ground {
             player_state.current = *midair::ID;
         } else if control.move_direction.y < -0.5 {
             player_state.current = *crouch::ID;

--- a/src/core/player/state/states/midair.rs
+++ b/src/core/player/state/states/midair.rs
@@ -22,6 +22,7 @@ pub fn player_state_transition(
     {
         let meta_handle = player_inputs.players[player_idx.0 as usize].selected_player;
         let meta = assets.get(meta_handle);
+        let control = &player_inputs.players[player_idx.0 as usize].control;
         if player_state.current != *ID {
             continue;
         }
@@ -31,6 +32,9 @@ pub fn player_state_transition(
             audio_center.play_sound(meta.sounds.land, meta.sounds.land_volume);
             // Switch to idle state
             player_state.current = *idle::ID;
+        } else if control.ragdoll_just_pressed {
+            // TODO audio
+            player_state.current = *ragdoll::ID;
         }
     }
 }

--- a/src/core/player/state/states/ragdoll.rs
+++ b/src/core/player/state/states/ragdoll.rs
@@ -1,0 +1,213 @@
+use rapier::vector;
+use rapier2d::prelude as rapier;
+
+use self::collisions::build_actor_rapier_collider;
+
+use super::*;
+
+pub static ID: Lazy<Ustr> = Lazy::new(|| ustr("core::ragdoll"));
+
+pub fn install(session: &mut Session) {
+    PlayerState::add_player_state_update_system(session, handle_player_state);
+}
+
+/// Track state of ragdoll.
+#[derive(HasSchema, Clone, Default)]
+pub struct PlayerRagdollState {
+    /// If ticking, cannot twitch
+    twitch_timer: Timer,
+
+    // Last frame that started twitch animation
+    last_twitch_anim_frame: u64,
+}
+
+pub fn handle_player_state(
+    entities: Res<Entities>,
+    time: Res<Time>,
+    mut player_states: CompMut<PlayerState>,
+    player_indexes: Comp<PlayerIdx>,
+    mut transform: CompMut<Transform>,
+    assets: Res<AssetServer>,
+    player_inputs: Res<MatchInputs>,
+    atlas_sprites: Comp<AtlasSprite>,
+    mut animations: CompMut<AnimationBankSprite>,
+    mut bodies: CompMut<KinematicBody>,
+    mut dynamic_bodies: CompMut<DynamicBody>,
+    mut player_body_attachments: CompMut<PlayerBodyAttachment>,
+    player_layers: Comp<PlayerLayers>,
+    mut ragdoll_states: CompMut<PlayerRagdollState>,
+    game_meta: Root<GameMeta>,
+    mut collision_world: CollisionWorld,
+    mut commands: Commands,
+) {
+    for (player_ent, (state, transform, animation, player_idx, atlas_sprite)) in
+        entities.iter_with((
+            &mut player_states,
+            &mut transform,
+            &mut animations,
+            &player_indexes,
+            &atlas_sprites,
+        ))
+    {
+        if state.current != *ID {
+            continue;
+        };
+
+        let meta_handle = player_inputs.players[player_idx.0 as usize].selected_player;
+        let meta = &*assets.get(meta_handle);
+        let player_physics = &game_meta.core.physics.player;
+        let control = player_inputs.players[player_idx.0 as usize].control;
+
+        match state.age {
+            0 => {
+                // TODO find right animation
+                animation.current = "ragdoll".into();
+
+                // drop item
+                commands.add(PlayerCommand::set_inventory(player_ent, None));
+
+                // Knock the player's hat off if they had one.
+                let layers = player_layers.get(player_ent).unwrap();
+                if let Some(hat_ent) = layers.hat_ent {
+                    player_body_attachments.remove(hat_ent);
+                    bodies.get_mut(hat_ent).unwrap().is_deactivated = false;
+                }
+
+                // Set to simulate physics
+                let dynamic_body =
+                    dynamic_bodies.get_mut_or_insert(player_ent, DynamicBody::default);
+                dynamic_body.is_dynamic = true;
+
+                let body = bodies.get_mut(player_ent).unwrap();
+                let player_physics = &game_meta.core.physics.player;
+                let pop_vel = Vec2::new(0.0, player_physics.ragdoll_initial_pop);
+                let ang_vel = player_physics.ragdoll_initial_ang_vel;
+                let sprite_dir = atlas_sprite.flip_x;
+                let current_vel = body.velocity;
+                let additional_mass = player_physics.ragdoll_additional_mass;
+
+                dynamic_body.push_simulation_command(Box::new(
+                    move |body: &mut rapier::RigidBody| {
+                        // Transfer current kinematic velocity to dynamic
+                        body.set_linvel((current_vel).into(), true);
+
+                        // Apply initial pop upward
+                        body.apply_impulse((pop_vel * body.mass()).into(), true);
+
+                        // Apply angular velocity
+                        let angular_dir = if sprite_dir { 1.0 } else { -1.0 };
+                        body.apply_torque_impulse(
+                            ang_vel
+                                * angular_dir
+                                * body.mass_properties().effective_angular_inertia(),
+                            true,
+                        );
+
+                        body.set_additional_mass(additional_mass, true);
+                    },
+                ));
+
+                ragdoll_states.insert(
+                    player_ent,
+                    PlayerRagdollState {
+                        twitch_timer: Timer::from_seconds(
+                            player_physics.ragdoll_twitch_delay,
+                            TimerMode::Once,
+                        ),
+                        last_twitch_anim_frame: 0,
+                    },
+                );
+                use_ragdoll_collider(player_ent, meta, &mut collision_world)
+            }
+            n if n > 1 => {
+                let ragdoll_state = ragdoll_states.get_mut(player_ent).unwrap();
+                if control.ragdoll_just_pressed {
+                    state.current = *idle::ID;
+                    animation.current = ustr("idle");
+
+                    // Switch back to kinematic
+                    dynamic_bodies.get_mut(player_ent).unwrap().is_dynamic = false;
+                    transform.rotation = Quat::default();
+
+                    let pop_vel = Vec2::new(0.0, player_physics.ragdoll_initial_pop);
+                    let body = bodies.get_mut(player_ent).unwrap();
+                    body.velocity = pop_vel;
+
+                    restore_player_collider(player_ent, meta, &mut collision_world);
+                }
+                // Handle twitching on input
+                else if control.move_direction != Vec2::ZERO {
+                    // Update timer determining if we may twitch on input
+                    let timer = &mut ragdoll_state.twitch_timer;
+                    timer.tick(time.delta());
+                    let can_twitch = timer.finished();
+
+                    animation.current = "ragdoll_twitch".into();
+                    ragdoll_state.last_twitch_anim_frame = n;
+
+                    // Check if touching solid, no twitching in air
+                    // TODO: Maybe it's fun to allow the minor air control?
+                    // let touching_solid = collision_world.tile_collision(*transform, body.shape)
+                    //     != TileCollisionKind::Empty;
+
+                    // Don't twitch when holding, only tap.
+                    if can_twitch && control.just_moved
+                    /*&& touching_solid*/
+                    {
+                        let dynamic_body = dynamic_bodies.get_mut(player_ent).unwrap();
+                        let twitch_vel = player_physics.ragdoll_twitch_vel;
+
+                        dynamic_body.push_simulation_command(Box::new(
+                            move |body: &mut rapier::RigidBody| {
+                                let mut lin_vel = *body.linvel();
+                                let dir_x = control.move_direction.x;
+                                lin_vel += vector!(dir_x * twitch_vel, 3.0 * twitch_vel);
+                                body.set_linvel(lin_vel, true);
+                            },
+                        ));
+
+                        timer.reset();
+                    }
+                } else {
+                    // Not twitching, back to normal animation if twitch anim held for at least 2 frames
+                    if n >= ragdoll_state.last_twitch_anim_frame + 4 {
+                        animation.current = "ragdoll".into();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Switch entity to a capsule collider based on collider
+/// from [`PlayerMeta`].
+pub fn use_ragdoll_collider(
+    entity: Entity,
+    player_meta: &PlayerMeta,
+    collision_world: &mut CollisionWorld,
+) {
+    // Build capsule from player size.
+    let radius = player_meta.body_size.x / 2.0;
+    let half_length = player_meta.body_size.y * 0.5 - radius;
+    let capsule = ColliderShape::CapsuleY {
+        half_length,
+        radius,
+    };
+    let mut builder = build_actor_rapier_collider(entity, capsule.shared_shape());
+
+    // Shift capsule slightly to lineup with animation
+    let translation = rapier::Translation::new(0.0, 5.0);
+    builder = builder.position(translation.into());
+
+    collision_world.set_actor_shape_from_builder(entity, builder, capsule);
+}
+
+/// Restore player shape back to default from `PlayerMeta`.
+fn restore_player_collider(
+    player_ent: Entity,
+    player_meta: &PlayerMeta,
+    collision_world: &mut CollisionWorld,
+) {
+    collision_world.set_actor_shape(player_ent, player_collider_shape(player_meta));
+}

--- a/src/core/player/state/states/walk.rs
+++ b/src/core/player/state/states/walk.rs
@@ -24,7 +24,9 @@ pub fn player_state_transition(
 
         let control = &player_inputs.players[player_idx.0 as usize].control;
 
-        if !body.is_on_ground {
+        if control.ragdoll_just_pressed {
+            player_state.current = *ragdoll::ID;
+        } else if !body.is_on_ground {
             player_state.current = *midair::ID;
         } else if control.move_direction.y < -0.5 {
             player_state.current = *crouch::ID;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -88,6 +88,7 @@ pub struct PlayerControlSetting {
     pub grab: InputKind,
     pub shoot: InputKind,
     pub slide: InputKind,
+    pub ragdoll: InputKind,
     pub menu_back: InputKind,
     pub menu_start: InputKind,
     pub menu_confirm: InputKind,

--- a/src/ui/main_menu/settings/controls.rs
+++ b/src/ui/main_menu/settings/controls.rs
@@ -104,6 +104,14 @@ pub(super) fn widget(
             ],
         ),
         (
+            localization.get("ragdoll"),
+            [
+                &mut mapping.keyboard1.ragdoll,
+                &mut mapping.keyboard2.ragdoll,
+                &mut mapping.gamepad.ragdoll,
+            ],
+        ),
+        (
             localization.get("pause"),
             [
                 &mut mapping.keyboard1.pause,


### PR DESCRIPTION
### Ragdoll State
Player may toggle ragdoll state with `F` or `Right bumper`.
- player body switches to capsule and simulates physics in ragdoll state.
- movement during ragdoll twitches the body slightly, small velocity + animation change.


### Minor Related Fixes
- set position with respect to parent no longer forced to 0 for all objects. Used this to tweak capsule position.
- Attached entities now rotate with parent.


### Animation
This will need another pass, for now I re-used some stuff we have. Making the corpse more obviously dead would be good (though I guess being able to reasonably play dead may also be amusing). 

https://github.com/fishfolk/jumpy/assets/35712032/9bdcbc0c-146b-4339-a7bd-4ed1ca1bb44d

https://github.com/fishfolk/jumpy/assets/35712032/f9004638-fc03-4ee6-8e6f-0f7f0ab1f3a3

https://github.com/fishfolk/jumpy/assets/35712032/5407bcf3-e9c9-4aa3-83e1-ba95adc3fcac


