### PR TITLE
fix: reset hat when dropped

### DIFF
--- a/src/core/player.rs
+++ b/src/core/player.rs
@@ -247,6 +247,7 @@ impl PlayerCommand {
         })
         .system()
     }
+
     /// Despawn a player.
     ///
     /// > **Note:** This is different than the [`kill`][Self::kill] event in that it immediately
@@ -288,6 +289,7 @@ impl PlayerCommand {
         })
         .system()
     }
+
     /// Set the player's inventory
     pub fn set_inventory(player: Entity, item: Option<Entity>) -> StaticSystem<(), ()> {
         (move |mut items_grabbed: CompMut<ItemGrabbed>,
@@ -310,6 +312,7 @@ impl PlayerCommand {
         })
         .system()
     }
+
     /// Have the player use the item they are carrying, if any.
     pub fn use_item(player: Entity) -> StaticSystem<(), ()> {
         (move |mut items_used: CompMut<ItemUsed>, inventories: CompMut<Inventory>| {
@@ -317,6 +320,29 @@ impl PlayerCommand {
             if let Some(item) = inventories.get(player).and_then(|x| x.0) {
                 // Use it
                 items_used.insert(item, ItemUsed { owner: player });
+            }
+        })
+        .system()
+    }
+
+    /// Drop the player's hat and reset its state.
+    pub fn drop_hat(player: Entity) -> StaticSystem<(), ()> {
+        (move |player_layers: Comp<PlayerLayers>,
+               mut player_body_attachments: CompMut<PlayerBodyAttachment>,
+               mut bodies: CompMut<KinematicBody>,
+               mut atlas_sprites: CompMut<AtlasSprite>| {
+            let Some(layers) = player_layers.get(player) else {
+                return;
+            };
+            let Some(hat_ent) = layers.hat_ent else {
+                return;
+            };
+            // Drop the hat
+            player_body_attachments.remove(hat_ent);
+            bodies.get_mut(hat_ent).unwrap().is_deactivated = false;
+            // Reset its states
+            if let Some(hat_sprite) = atlas_sprites.get_mut(hat_ent) {
+                hat_sprite.color.set_a(1.0);
             }
         })
         .system()

--- a/src/core/player/state/states/dead.rs
+++ b/src/core/player/state/states/dead.rs
@@ -27,8 +27,6 @@ pub fn handle_player_state(
     killed_players: Comp<PlayerKilled>,
     _sprites: Comp<AtlasSprite>,
     _transform: Comp<Transform>,
-    player_layers: Comp<PlayerLayers>,
-    mut player_body_attachments: CompMut<PlayerBodyAttachment>,
     mut kinematic_bodies: CompMut<KinematicBody>,
     mut dynamic_bodies: CompMut<DynamicBody>,
     mut animations: CompMut<AnimationBankSprite>,
@@ -49,13 +47,9 @@ pub fn handle_player_state(
             // let sprite = sprites.get(player_ent).unwrap();
             // let player_on_right = !sprite.flip_x;
             // let transform = transform.get(player_ent).unwrap();
-            let layers = player_layers.get(player_ent).unwrap();
 
             // Knock the player's hat off if they had one.
-            if let Some(hat_ent) = layers.hat_ent {
-                player_body_attachments.remove(hat_ent);
-                kinematic_bodies.get_mut(hat_ent).unwrap().is_deactivated = false;
-            }
+            commands.add(PlayerCommand::drop_hat(player_ent));
 
             if !dynamic_bodies.contains(player_ent) {
                 let dynamic_body = DynamicBody::new(true);

--- a/src/core/player/state/states/ragdoll.rs
+++ b/src/core/player/state/states/ragdoll.rs
@@ -33,8 +33,6 @@ pub fn handle_player_state(
     mut animations: CompMut<AnimationBankSprite>,
     mut bodies: CompMut<KinematicBody>,
     mut dynamic_bodies: CompMut<DynamicBody>,
-    mut player_body_attachments: CompMut<PlayerBodyAttachment>,
-    player_layers: Comp<PlayerLayers>,
     mut ragdoll_states: CompMut<PlayerRagdollState>,
     game_meta: Root<GameMeta>,
     mut collision_world: CollisionWorld,
@@ -67,11 +65,7 @@ pub fn handle_player_state(
                 commands.add(PlayerCommand::set_inventory(player_ent, None));
 
                 // Knock the player's hat off if they had one.
-                let layers = player_layers.get(player_ent).unwrap();
-                if let Some(hat_ent) = layers.hat_ent {
-                    player_body_attachments.remove(hat_ent);
-                    bodies.get_mut(hat_ent).unwrap().is_deactivated = false;
-                }
+                commands.add(PlayerCommand::drop_hat(player_ent));
 
                 // Set to simulate physics
                 let dynamic_body =


### PR DESCRIPTION
Closes #930 

- Adds a `PlayerCommand` to drop a player's hat and reset its properties
- Replaces all instances of manually dropping a hat to use the new convenience command