### PR TITLE
fix(networking): Specify local input delay and max prediction window from metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "bones_asset"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "bones_bevy_renderer"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "anyhow",
  "atomicell",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "bones_framework"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "bones_lib"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "bones_ecs",
  "instant",
@@ -1240,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "bones_matchmaker_proto"
 version = "0.2.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "serde",
 ]
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "bones_schema"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "append-only-vec",
  "bones_schema_macros",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "bones_schema_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1276,7 +1276,7 @@ dependencies = [
 [[package]]
 name = "bones_scripting"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "async-channel",
  "bevy_tasks",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "bones_utils"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "bones_utils_macros",
  "branches",
@@ -1314,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "bones_utils_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "quote",
  "venial",
@@ -2951,15 +2951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4321,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "quinn_runtime_bevy"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#6ab6af0f9a30a1e9b745a57481fae0fb227a5a7a"
+source = "git+https://github.com/fishfolk/bones#ecc833a59cec769228062faa094572a343b8cdf7"
 dependencies = [
  "async-executor",
  "async-io",
@@ -4948,7 +4939,7 @@ checksum = "9635466532d454fa020acbb12f629f1fc02fc9b4d5b39cc72ca478be37e314bc"
 dependencies = [
  "bitvec",
  "fastrand 1.9.0",
- "itertools 0.10.5",
+ "itertools",
  "log",
  "nohash-hasher",
 ]

--- a/assets/game.yaml
+++ b/assets/game.yaml
@@ -29,6 +29,10 @@ main_menu:
 
   menu_width: 350
 
+network:
+  local_input_delay: 2
+  max_prediction_window: 7
+
 default_settings:
   main_volume: 1.0
   matchmaking_server: matchmaker.bones.fishfolk.org:65534

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,20 +64,20 @@ pub struct NetworkMeta {
 
 impl Default for NetworkMeta {
     fn default() -> Self {
-        let local_input_delay = if !cfg!(target_arch = "wasm32") {
-            bones_framework::networking::NETWORK_LOCAL_INPUT_DELAY_DEFAULT
-        } else {
-            0
-        };
-        let max_prediction_window = if !cfg!(target_arch = "wasm32") {
-            bones_framework::networking::NETWORK_MAX_PREDICTION_WINDOW_DEFAULT
-        } else {
-            0
-        };
-
-        Self {
-            local_input_delay,
-            max_prediction_window,
+        #[cfg(target_arch = "wasm32")]
+        {
+            Self {
+                local_input_delay: 0,
+                max_prediction_window: 0,
+            }
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            Self {
+                local_input_delay: bones_framework::networking::NETWORK_LOCAL_INPUT_DELAY_DEFAULT,
+                max_prediction_window:
+                    bones_framework::networking::NETWORK_MAX_PREDICTION_WINDOW_DEFAULT,
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,24 @@ pub struct GameMeta {
     pub theme: ui::UiTheme,
     pub main_menu: ui::main_menu::MainMenuMeta,
     pub music: GameMusic,
+    pub network: NetworkMeta,
+}
+
+#[derive(HasSchema, Copy, Clone, Debug)]
+#[repr(C)]
+pub struct NetworkMeta {
+    pub max_prediction_window: usize,
+    pub local_input_delay: usize,
+}
+
+impl Default for NetworkMeta {
+    fn default() -> Self {
+        Self {
+            local_input_delay: bones_framework::networking::NETWORK_LOCAL_INPUT_DELAY_DEFAULT,
+            max_prediction_window:
+                bones_framework::networking::NETWORK_MAX_PREDICTION_WINDOW_DEFAULT,
+        }
+    }
 }
 
 #[derive(HasSchema, Clone, Debug, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,10 +64,20 @@ pub struct NetworkMeta {
 
 impl Default for NetworkMeta {
     fn default() -> Self {
+        let local_input_delay = if !cfg!(target_arch = "wasm32") {
+            bones_framework::networking::NETWORK_LOCAL_INPUT_DELAY_DEFAULT
+        } else {
+            0
+        };
+        let max_prediction_window = if !cfg!(target_arch = "wasm32") {
+            bones_framework::networking::NETWORK_MAX_PREDICTION_WINDOW_DEFAULT
+        } else {
+            0
+        };
+
         Self {
-            local_input_delay: bones_framework::networking::NETWORK_LOCAL_INPUT_DELAY_DEFAULT,
-            max_prediction_window:
-                bones_framework::networking::NETWORK_MAX_PREDICTION_WINDOW_DEFAULT,
+            local_input_delay,
+            max_prediction_window,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,8 @@ pub struct NetworkMeta {
     pub local_input_delay: usize,
 }
 
+// In wasm build get derivable_impls clippy warning which breaks CI
+#[allow(clippy::derivable_impls)]
 impl Default for NetworkMeta {
     fn default() -> Self {
         #[cfg(target_arch = "wasm32")]

--- a/src/ui/main_menu/map_select.rs
+++ b/src/ui/main_menu/map_select.rs
@@ -54,7 +54,11 @@ pub fn widget(
             let session_runner: Box<dyn SessionRunner> = match network_socket {
                 Some(socket) => Box::new(GgrsSessionRunner::<NetworkInputConfig>::new(
                     FPS,
-                    GgrsSessionRunnerInfo::from(socket.as_ref()),
+                    GgrsSessionRunnerInfo::new(
+                        socket.as_ref(),
+                        Some(meta.network.max_prediction_window),
+                        Some(meta.network.local_input_delay),
+                    ),
                 )),
                 None => Box::<JumpyDefaultMatchRunner>::default(),
             };


### PR DESCRIPTION
I opened a PR in bones to expose these settings for networking, instead of hard coding in engine. (https://github.com/fishfolk/bones/pull/354)

The defaults of these values were also changed in bones such that things are feeling much better in network play with ping around 100ms-150ms.

Now we may tune in metadata, though settings only take effect if new network match is created. This will not pass CI until bones PR is merged + bones version updated.

I think retuning this is a quick and big improvement for high-latency network play. I have WIP for visually smoothing corrections - but I think addressing core issues with networking and getting it as good as possible is priority vs trying to improve how corrections look. Will get that shipped at some point, but want to do some playtesting with more people than myself with various net conditions before spending any more time on net corrections, as it's hard to get right.