### PR TITLE
chore(release): Bump to 0.11.2 for release / hopefully package all platforms successfully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "jumpy"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-channel",
  "bevy_dylib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "A tactical 2D shooter"
 edition     = "2021"
 license     = "MIT OR Apache-2.0"
 name        = "jumpy"
-version     = "0.11.1"
+version     = "0.11.2"
 
 [features]
 default = []

--- a/packs/devpack/pack.yaml
+++ b/packs/devpack/pack.yaml
@@ -1,7 +1,7 @@
 name: Dev Pack
 id: devpack_01hgrar12df9rva3mxrh2x3vgj
 version: 0.1.0
-game_version: 0.11.1
+game_version: 0.11.2
 root: ./assets.yaml
 schemas:
   - /items/blunderbass/BlunderbassMeta.schema.yaml


### PR DESCRIPTION
0.11.1 macOS x86_64 build failed during release - seemed related to dep on my fork of rapier, which we no longer need as PR was merged. Crossing my fingers that #946 resolved that issue and 0.11.2 goes smoothly.