### PR TITLE
fix: Fix musket/blunderbass kickback and blunderbass bullet speed being incorrect post-physics refactor

### DIFF
--- a/assets/elements/item/sniper_rifle/musket.yaml
+++ b/assets/elements/item/sniper_rifle/musket.yaml
@@ -20,4 +20,4 @@ fin_anim: grab_2
 angular_velocity: 0.1
 throw_velocity: 360
 grab_offset: [23, 0]
-kickback: 15
+kickback: 900

--- a/packs/devpack/items/blunderbass/blunderbass.yaml
+++ b/packs/devpack/items/blunderbass/blunderbass.yaml
@@ -8,5 +8,4 @@ cooldown: 0.75
 bullet_count: 4
 bullet_spread: 0.8
 bullet: ./bullet.yaml
-kickback: 10
-
+kickback: 600

--- a/packs/devpack/items/blunderbass/bullet.yaml
+++ b/packs/devpack/items/blunderbass/bullet.yaml
@@ -1,5 +1,5 @@
 lifetime: 1.0
-speed: 12
+speed: 720
 body_diameter: 15
 atlas: ./bullet.atlas.yaml
 

--- a/packs/devpack/maps/devlevel_1.map.yaml
+++ b/packs/devpack/maps/devlevel_1.map.yaml
@@ -1236,7 +1236,7 @@ layers:
   - pos:
     - 432.0
     - 555.0
-    element: core:/elements/item/sword/sword.element.yaml
+    element: /items/blunderbass/element.yaml
   - pos:
     - 300.0
     - 710.0


### PR DESCRIPTION
Found a few velocity-based meta values I missed in the #925 refactor.