### PR TITLE
feat: bullet spawn offset in yaml

### DIFF
--- a/assets/elements/item/buss/buss.yaml
+++ b/assets/elements/item/buss/buss.yaml
@@ -5,6 +5,7 @@ cooldown: 1000ms
 bullet_meta: ./bullet/buss.bullet.yaml
 bullet_count: 10
 bullet_spread: 0.3
+bullet_spawn_offset: [28, 6]
 
 shoot_fps: 15
 shoot_frames: 3

--- a/assets/elements/item/machine_gun/machine_gun.yaml
+++ b/assets/elements/item/machine_gun/machine_gun.yaml
@@ -5,6 +5,7 @@ cooldown: 125ms
 empty_cooldown: 600ms
 bullet_meta: ./bullet/machine_gun.bullet.yaml
 bullet_spread: 0.1
+bullet_spawn_offset: [30, 8]
 
 shoot_sound_volume: 0.1
 shoot_sound: ./shoot/shoot.ogg

--- a/assets/elements/item/musket/musket.yaml
+++ b/assets/elements/item/musket/musket.yaml
@@ -3,6 +3,7 @@ atlas: ./musket.atlas.yaml
 max_ammo: 4
 cooldown: 600ms
 bullet_meta: ./bullet/musket.bullet.yaml
+bullet_spawn_offset: [15, 0]
 
 shoot_fps: 15
 shoot_frames: 3

--- a/assets/elements/item/periscope/periscope.yaml
+++ b/assets/elements/item/periscope/periscope.yaml
@@ -3,6 +3,7 @@ atlas: ./periscope.atlas.yaml
 max_ammo: 6
 cooldown: 700ms
 bullet_meta: ./bullet/periscope.bullet.yaml
+bullet_spawn_offset: [30, 25]
 
 shoot_fps: 15
 shoot_frames: 3

--- a/assets/elements/item/sniper_rifle/musket.yaml
+++ b/assets/elements/item/sniper_rifle/musket.yaml
@@ -3,6 +3,7 @@ atlas: ./sniper_rifle.atlas.yaml
 max_ammo: 2
 cooldown: 300ms
 bullet_meta: ./bullet/sniper.bullet.yaml
+bullet_spawn_offset: [15, 0]
 
 shoot_fps: 15
 shoot_frames: 3

--- a/src/core/elements/buss.rs
+++ b/src/core/elements/buss.rs
@@ -19,6 +19,7 @@ pub struct BussMeta {
     pub bullet_count: u32,
     pub bullet_spread: f32,
     pub bullet_meta: Handle<BulletMeta>,
+    pub bullet_spawn_offset: Vec2,
     pub kickback: f32,
 
     pub shoot_fps: f32,
@@ -170,6 +171,7 @@ fn update(
             bullet_meta,
             bullet_count,
             bullet_spread,
+            bullet_spawn_offset,
             shoot_sound,
             empty_shoot_sound,
             shoot_sound_volume,
@@ -208,10 +210,14 @@ fn update(
                 player_body.velocity.x = if player_flip_x { 1.0 } else { -1.0 } * kickback;
 
                 let mut shoot_animation_transform = *transforms.get(entity).unwrap();
+                let bullet_spawn_offset = *bullet_spawn_offset;
                 shoot_animation_transform.translation.z += 1.0;
-                shoot_animation_transform.translation.y += 6.0;
-                shoot_animation_transform.translation.x +=
-                    if player_sprite.flip_x { -28.0 } else { 28.0 };
+                shoot_animation_transform.translation.y += bullet_spawn_offset.y;
+                shoot_animation_transform.translation.x += if player_sprite.flip_x {
+                    -bullet_spawn_offset.x
+                } else {
+                    bullet_spawn_offset.x
+                };
 
                 let shoot_fps = *shoot_fps;
                 let shoot_frames = *shoot_frames;

--- a/src/core/elements/machine_gun.rs
+++ b/src/core/elements/machine_gun.rs
@@ -19,6 +19,7 @@ pub struct MachineGunMeta {
     pub empty_cooldown: Duration,
     pub bullet_meta: Handle<BulletMeta>,
     pub bullet_spread: f32,
+    pub bullet_spawn_offset: Vec2,
     pub kickback: f32,
 
     pub shoot_sound_volume: f64,
@@ -173,8 +174,9 @@ fn update(
             max_ammo,
             cooldown,
             empty_cooldown,
-            bullet_meta,
             bullet_spread,
+            bullet_meta,
+            bullet_spawn_offset,
             shoot_sound,
             empty_shoot_sound,
             shoot_sound_volume,
@@ -246,10 +248,14 @@ fn update(
                     player_body.velocity.x = if player_flip_x { 1.0 } else { -1.0 } * kickback;
 
                     let mut shoot_animation_transform = *transforms.get(entity).unwrap();
+                    let bullet_spawn_offset = *bullet_spawn_offset;
                     shoot_animation_transform.translation.z += 1.0;
-                    shoot_animation_transform.translation.y += 8.0;
-                    shoot_animation_transform.translation.x +=
-                        if player_sprite.flip_x { -30.0 } else { 30.0 };
+                    shoot_animation_transform.translation.y += bullet_spawn_offset.y;
+                    shoot_animation_transform.translation.x += if player_sprite.flip_x {
+                        -bullet_spawn_offset.x
+                    } else {
+                        bullet_spawn_offset.x
+                    };
 
                     let bullet_meta = *bullet_meta;
                     let bullet_spread = *bullet_spread;

--- a/src/core/elements/musket.rs
+++ b/src/core/elements/musket.rs
@@ -17,6 +17,7 @@ pub struct MusketMeta {
     pub max_ammo: u32,
     pub cooldown: Duration,
     pub bullet_meta: Handle<BulletMeta>,
+    pub bullet_spawn_offset: Vec2,
     pub kickback: f32,
 
     pub shoot_fps: f32,
@@ -166,6 +167,7 @@ fn update(
             shoot_lifetime,
             cooldown,
             bullet_meta,
+            bullet_spawn_offset,
             shoot_sound,
             empty_shoot_sound,
             shoot_sound_volume,
@@ -204,9 +206,13 @@ fn update(
                 player_body.velocity.x = if player_flip_x { 1.0 } else { -1.0 } * kickback;
 
                 let mut shoot_animation_transform = *transforms.get(entity).unwrap();
+                let bullet_spawn_offset = *bullet_spawn_offset;
                 shoot_animation_transform.translation.z += 1.0;
-                shoot_animation_transform.translation.x +=
-                    if player_sprite.flip_x { -15.0 } else { 15.0 };
+                shoot_animation_transform.translation.x += if player_sprite.flip_x {
+                    -bullet_spawn_offset.x
+                } else {
+                    bullet_spawn_offset.x
+                };
 
                 let shoot_fps = *shoot_fps;
                 let shoot_frames = *shoot_frames;

--- a/src/core/elements/periscope.rs
+++ b/src/core/elements/periscope.rs
@@ -17,6 +17,7 @@ pub struct PeriscopeMeta {
     pub max_ammo: u32,
     pub cooldown: Duration,
     pub bullet_meta: Handle<BulletMeta>,
+    pub bullet_spawn_offset: Vec2,
     pub kickback: f32,
 
     pub shoot_fps: f32,
@@ -168,6 +169,7 @@ fn update(
             shoot_lifetime,
             cooldown,
             bullet_meta,
+            bullet_spawn_offset,
             shoot_sound,
             empty_shoot_sound,
             shoot_sound_volume,
@@ -206,10 +208,14 @@ fn update(
                 player_body.velocity.x = if player_flip_x { 1.0 } else { -1.0 } * kickback;
 
                 let mut shoot_animation_transform = *transforms.get(entity).unwrap();
+                let bullet_spawn_offset = *bullet_spawn_offset;
                 shoot_animation_transform.translation.z += 1.0;
-                shoot_animation_transform.translation.y += 25.0;
-                shoot_animation_transform.translation.x +=
-                    if player_sprite.flip_x { -30.0 } else { 30.0 };
+                shoot_animation_transform.translation.y += bullet_spawn_offset.y;
+                shoot_animation_transform.translation.x += if player_sprite.flip_x {
+                    -bullet_spawn_offset.x
+                } else {
+                    bullet_spawn_offset.x
+                };
 
                 let shoot_fps = *shoot_fps;
                 let shoot_frames = *shoot_frames;


### PR DESCRIPTION
I did what @MaxCWhitehead told me earlier, created a `bullet_spawn_offset` field in `.yaml`. I added this to all the weapons because it makes it easier for new contributors to locate and modify in case we change the artworks.