### PR TITLE
fix(crash): Update parry2d to 0.13.7 (use rapier fork) for crash fix in QBVH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3853,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.13.6"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94683d8d7e785fe84b02d0a0dbe0fcf359c031c338dd6d144de958573c570c25"
+checksum = "a996b83a7a12522b395c54f4ba59593b782e8004794c0212a2f487ed7ac6e419"
 dependencies = [
  "approx",
  "arrayvec",
@@ -4334,7 +4334,7 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 [[package]]
 name = "rapier2d"
 version = "0.18.0"
-source = "git+https://github.com/dimforge/rapier?rev=e69e73e589cf4525c96ee7b919032c80ce205244#e69e73e589cf4525c96ee7b919032c80ce205244"
+source = "git+https://github.com/MaxCWhitehead/rapier.git?rev=29c72c6c282e7c40987c0d0d0ce3089ea019a532#29c72c6c282e7c40987c0d0d0ce3089ea019a532"
 dependencies = [
  "approx",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ tracing             = "0.1.37"
 puffin              = { version = "0.17.0", features = ["web"] }
 puffin_egui         = "0.23.0"
 petgraph            = "0.6.4"
-rapier2d            = { git = "https://github.com/dimforge/rapier", rev= "e69e73e589cf4525c96ee7b919032c80ce205244",  features = ["debug-render", "enhanced-determinism"] }
+# Use rapier w/ parry2d 0.13.7 for qbvh crash fix: https://github.com/dimforge/parry/pull/185
+rapier2d            = { git = "https://github.com/MaxCWhitehead/rapier.git", rev= "29c72c6c282e7c40987c0d0d0ce3089ea019a532",  features = ["debug-render", "enhanced-determinism"] }
 indexmap            = "2.0.0"
 serde               = { version = "1.0.188", features = ["derive"] }
 shiftnanigans       = "0.3.3"


### PR DESCRIPTION
I've been frequently hitting a crash / bug in parry2d QBVH involving incremental update. Sometimes it crashes, sometimes is a framerate death spiral / fully locks up.

```
thread 'main' panicked at /Users/max/.cargo/registry/src/index.crates.io-6f17d22bba15001f/parry2d-0.13.6/src/partitioning/qbvh/update.rs:367:54:
attempt to add with overflow
```

Appears to be been fixed at https://github.com/dimforge/parry/commit/7df2728afc8eff3c4ba7256b3344968481524b37 in parry2d 0.13.7. Updated rapier to use a fork with parry2d update as not updated in rapier yet.