### PR TITLE
fix(ui): Fix not being able to navigate online menu without mouse

### DIFF
--- a/src/ui/network_game.rs
+++ b/src/ui/network_game.rs
@@ -138,6 +138,7 @@ pub fn network_game_menu(
                         }
                         if BorderedButton::themed(normal_button_style, lan)
                             .show(ui)
+                            .focus_by_default(ui)
                             .clicked()
                         {
                             state.match_kind = MatchKind::Lan(default());


### PR DESCRIPTION
Focus a button by default so can be navigated without mouse. Fixes #939 