### PR TITLE
fix: Fix machine gun animation and musket

### DIFF
--- a/src/core/elements/machine_gun.rs
+++ b/src/core/elements/machine_gun.rs
@@ -191,15 +191,14 @@ fn update(
         machine_gun.cooldown.tick(time.delta());
         machine_gun.empty_cooldown.tick(time.delta());
 
+        let sprite = sprites.get_mut(entity).unwrap();
+        // Reset machine gun animation
+        if let MachineGunState::Idle = machine_gun.state {
+            sprite.index = 0;
+        }
+
         // If the item is being held
         if let Some(Inv { player, .. }) = player_inventories.find_item(entity) {
-            let sprite = sprites.get_mut(entity).unwrap();
-
-            // Reset machine gun animation
-            if let MachineGunState::Idle = machine_gun.state {
-                sprite.index = 0;
-            }
-
             // If the item is being used
             let item_used = items_used.remove(entity).is_some();
             if item_used {
@@ -294,6 +293,8 @@ fn update(
                     }
                 }
             }
+        } else {
+            machine_gun.state = MachineGunState::Idle;
         }
 
         // If the item was dropped

--- a/src/core/elements/musket.rs
+++ b/src/core/elements/musket.rs
@@ -208,6 +208,7 @@ fn update(
                 let mut shoot_animation_transform = *transforms.get(entity).unwrap();
                 let bullet_spawn_offset = *bullet_spawn_offset;
                 shoot_animation_transform.translation.z += 1.0;
+                shoot_animation_transform.translation.y += bullet_spawn_offset.y;
                 shoot_animation_transform.translation.x += if player_sprite.flip_x {
                     -bullet_spawn_offset.x
                 } else {


### PR DESCRIPTION
The musket simply didn't call `bullet_spawn_offset.y`, no big deal.

The machine gun animation would get frozen when dropped. Had to add an "else" for when the item is not being held, because `items_dropped.get` is called only when in fact the item got dropped, and if the player gets killed while shooting, the animation would still froze, as it wouldn't be IN FACT dropped.

It even made me think about the ammunition reload system of all guns.
```
        if items_dropped.get(entity).is_some() {
            // reload gun
            gun.ammo = *max_ammo;
        }
```
Here, reloading will only take place if the item is dropped. This means that if you die holding a musket with half the ammo, the next player to pick it up will get it with half the ammo. Is that what we really want? Or do we want the ammo to be reloaded?


