### PR TITLE
fix: Prevent pausing in online from timing out network, allow game to continue running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "bones_asset"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -1277,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "bones_bevy_renderer"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1294,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "anyhow",
  "atomicell",
@@ -1311,7 +1311,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "bones_ecs_macros_core",
  "proc-macro2",
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs_macros_core"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "bones_framework"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1379,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "bones_lib"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "bones_ecs",
  "instant",
@@ -1388,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "bones_matchmaker_proto"
 version = "0.2.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "iroh-net",
  "serde",
@@ -1397,7 +1397,7 @@ dependencies = [
 [[package]]
 name = "bones_schema"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "append-only-vec",
  "bones_schema_macros",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "bones_schema_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "bones_scripting"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "async-channel",
  "bevy_tasks",
@@ -1442,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "bones_utils"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "bones_utils_macros",
  "branches",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "bones_utils_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#8a9492b4af9d111c672c654badbc9872e4c05fde"
+source = "git+https://github.com/fishfolk/bones#f8959575061f99fc202eb0be9f944e9505e4dfb3"
 dependencies = [
  "quote",
  "venial",

--- a/src/core.rs
+++ b/src/core.rs
@@ -120,6 +120,8 @@ pub struct JumpyDefaultMatchRunner {
     pub input_collector: PlayerInputCollector,
     pub accumulator: f64,
     pub last_run: Option<Instant>,
+    /// Disables local input for session.
+    disable_local_input: bool,
 }
 
 impl SessionRunner for JumpyDefaultMatchRunner {
@@ -153,7 +155,13 @@ impl SessionRunner for JumpyDefaultMatchRunner {
                     let Some(source) = &player_input.control_source else {
                         return;
                     };
-                    player_input.control = *input.get(source).unwrap();
+                    if !self.disable_local_input {
+                        player_input.control = *input.get(source).unwrap();
+                    } else {
+                        // This runner is only used for offline play, use default control for all to
+                        // disable input by using default (no input).
+                        player_input.control = PlayerControl::default();
+                    }
                 });
             }
 
@@ -189,5 +197,9 @@ impl SessionRunner for JumpyDefaultMatchRunner {
 
     fn restart_session(&mut self) {
         *self = JumpyDefaultMatchRunner::default();
+    }
+
+    fn disable_local_input(&mut self, disable_input: bool) {
+        self.disable_local_input = disable_input;
     }
 }

--- a/src/ui/pause_menu.rs
+++ b/src/ui/pause_menu.rs
@@ -281,6 +281,8 @@ fn pause_session(paused: bool, is_online: bool, session: &mut Session, remain_in
         // Instead we disable the input so it is not captured by game while paused.
         session.runner.disable_local_input(paused);
     } else if !paused && !remain_inactive {
-        session.active = !paused;
+        session.active = true;
+    } else if paused {
+        session.active = false;
     }
 }


### PR DESCRIPTION
Previously pausing in online would pause net loop and cause timeout. Now game continues to simulate in background, and inputs are disabled while pause menu open in online.

Dependent on https://github.com/fishfolk/bones/pull/411, CI will fail until updated.

Fixes https://github.com/fishfolk/jumpy/issues/1001