### PR TITLE
fix(player_select): Fix adding AI in first slot + starting game with AI but no player

### DIFF
--- a/src/ui/main_menu/player_select.rs
+++ b/src/ui/main_menu/player_select.rs
@@ -66,14 +66,18 @@ pub fn widget(
     let mut ready_players = 0;
     let mut unconfirmed_players = 0;
 
+    let mut at_least_one_non_ai_ready = false;
     for slot in &state.slots {
         if slot.confirmed {
             ready_players += 1;
+            if !slot.is_ai {
+                at_least_one_non_ai_ready = true;
+            }
         } else if slot.active {
             unconfirmed_players += 1;
         }
     }
-    let may_continue = ready_players >= 1 && unconfirmed_players == 0;
+    let may_continue = ready_players >= 1 && unconfirmed_players == 0 && at_least_one_non_ai_ready;
 
     #[cfg(not(target_arch = "wasm32"))]
     if let Some(socket) = network_socket.as_ref() {

--- a/src/ui/main_menu/player_select.rs
+++ b/src/ui/main_menu/player_select.rs
@@ -613,12 +613,13 @@ fn player_select_panel(
 
                     if !is_network {
                         ui.add_space(meta.theme.font_styles.bigger.size);
-                        if BorderedButton::themed(
-                            &meta.theme.buttons.normal,
-                            localization.get("add-ai-player"),
-                        )
-                        .show(ui)
-                        .clicked()
+                        if *slot_id != 0
+                            && BorderedButton::themed(
+                                &meta.theme.buttons.normal,
+                                localization.get("add-ai-player"),
+                            )
+                            .show(ui)
+                            .clicked()
                         {
                             slot.is_ai = true;
                             slot.confirmed = true;


### PR DESCRIPTION
Remove ability to add AI player to first slot, reserved for at least one player.

FIx being able to start game without a real player.

Closes #974  and #956 