### PR TITLE
fix: Make sure pause menu closes after a menu map change

### DIFF
--- a/src/ui/pause_menu.rs
+++ b/src/ui/pause_menu.rs
@@ -144,6 +144,7 @@ fn pause_menu_system(
             session_runner: Box::<JumpyDefaultMatchRunner>::default(),
             score: default(),
         });
+        pause_menu.menu_open = false;
     }
 
     if close_pause_menu {


### PR DESCRIPTION
Fixes #1010