### PR TITLE
fix: Switch to AudioCenter implemented in bones - remove from Jumpy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,12 +349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-arena"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5450eca8ce5abcfd5520727e975ebab30ccca96030550406b0ca718b224ead10"
-
-[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "bones_asset"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -1235,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "bones_bevy_renderer"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1252,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "anyhow",
  "atomicell",
@@ -1269,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "bones_ecs_macros_core",
  "proc-macro2",
@@ -1278,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "bones_ecs_macros_core"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1288,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "bones_framework"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
@@ -1337,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "bones_lib"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "bones_ecs",
  "instant",
@@ -1346,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "bones_matchmaker_proto"
 version = "0.2.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "iroh-net",
  "serde",
@@ -1355,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "bones_schema"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "append-only-vec",
  "bones_schema_macros",
@@ -1373,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "bones_schema_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1383,7 +1377,7 @@ dependencies = [
 [[package]]
 name = "bones_scripting"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "async-channel 1.9.0",
  "bevy_tasks",
@@ -1400,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "bones_utils"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "bones_utils_macros",
  "branches",
@@ -1421,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "bones_utils_macros"
 version = "0.3.0"
-source = "git+https://github.com/fishfolk/bones#71878a27a4969848e33f92867adccf0e1e10971a"
+source = "git+https://github.com/fishfolk/bones#66f35a5efeec0391deda3d8be6327809f278c051"
 dependencies = [
  "quote",
  "venial",
@@ -3052,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
 dependencies = [
  "mint",
 ]
@@ -4065,17 +4059,18 @@ dependencies = [
 
 [[package]]
 name = "kira"
-version = "0.8.7"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8968f1eda49cdf4f6406fd5ffe590c3ca2778a1b0e50b5684974b138a99dfb2f"
+checksum = "5c48d4719537e9af8467214f42c76425afbde24fb33e8d06686ab764e2a98e0b"
 dependencies = [
- "atomic-arena",
  "cpal",
- "glam 0.25.0",
+ "glam 0.28.0",
  "mint",
+ "paste",
  "ringbuf",
  "send_wrapper",
  "symphonia",
+ "triple_buffer",
 ]
 
 [[package]]
@@ -7529,6 +7524,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "triple_buffer"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e66931c8eca6381f0d34656a9341f09bd462010488c1a3bc0acd3f2d08dffce"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,210 +1,44 @@
-use std::collections::VecDeque;
-
-use bones_framework::prelude::kira::{
-    sound::{
-        static_sound::{StaticSoundHandle, StaticSoundSettings},
-        PlaybackState,
-    },
-    tween::{self, Tween},
-    Volume,
-};
-
 use crate::prelude::*;
 
 pub mod music;
-
+use kira::sound::static_sound::StaticSoundSettings;
 pub use music::*;
 
 pub fn game_plugin(game: &mut Game) {
     game.init_shared_resource::<AudioCenter>();
 
-    let session = game.sessions.create(SessionNames::AUDIO);
+    let session = match game.sessions.get_mut(DEFAULT_BONES_AUDIO_SESSION) {
+        Some(session) => session,
+        None => panic!("Audio plugin failed to find `DEFAULT_BONES_AUDIO_SESSION`, make sure jumpy audio plugin is installed after bones default plugins.")
+    };
 
-    // Audio doesn't do any rendering
-    session.visible = false;
-    session
-        .stages
-        .add_system_to_stage(First, music_system)
-        .add_system_to_stage(First, process_audio_events)
-        .add_system_to_stage(Last, kill_finished_audios);
+    session.stages.add_system_to_stage(First, music_system);
 }
 
-/// A resource that can be used to control game audios.
-#[derive(HasSchema)]
-#[schema(no_clone)]
-pub struct AudioCenter {
-    /// Buffer for audio events that have not yet been processed.
-    events: VecDeque<AudioEvent>,
-    /// The handle to the current music.
-    music: Option<Audio>,
-}
-
-impl Default for AudioCenter {
-    fn default() -> Self {
-        Self {
-            events: VecDeque::with_capacity(16),
-            music: None,
-        }
-    }
-}
-
-impl AudioCenter {
-    /// Push an audio event to the queue for later processing.
-    pub fn event(&mut self, event: AudioEvent) {
-        self.events.push_back(event);
-    }
-
-    /// Get the playback state of the music.
-    pub fn music_state(&self) -> Option<PlaybackState> {
-        self.music.as_ref().map(|m| m.handle.state())
-    }
-
-    /// Play a sound. These are usually short audios that indicate something
-    /// happened in game, e.g. a player jump, an explosion, etc.
-    pub fn play_sound(&mut self, sound_source: Handle<AudioSource>, volume: f64) {
-        self.events.push_back(AudioEvent::PlaySound {
-            sound_source,
-            volume,
-        })
-    }
-
-    /// Play some music. These may or may not loop.
+/// Extension of bones [`AudioCenter`].
+pub trait AudioCenterExt {
+    /// Play some music using [`StaticSoundSettings`]. These may or may not loop.
     ///
-    /// Any current music is stopped.
-    pub fn play_music(
+    /// `force_restart` determines if the same music is played if it should restart or not.
+    fn play_music_from_settings(
         &mut self,
         sound_source: Handle<AudioSource>,
         sound_settings: StaticSoundSettings,
+        force_restart: bool,
+    );
+}
+
+impl AudioCenterExt for AudioCenter {
+    fn play_music_from_settings(
+        &mut self,
+        sound_source: Handle<AudioSource>,
+        sound_settings: StaticSoundSettings,
+        force_restart: bool,
     ) {
-        self.events.push_back(AudioEvent::PlayMusic {
+        self.push_event(AudioEvent::PlayMusic {
             sound_source,
             sound_settings: Box::new(sound_settings),
+            force_restart,
         });
-    }
-}
-
-/// An audio event that may be sent to the [`AudioCenter`] resource for
-/// processing.
-#[derive(Clone, Debug)]
-pub enum AudioEvent {
-    /// Update the volume of all audios using the new values.
-    VolumeChange {
-        main_volume: f64,
-        music_volume: f64,
-        effects_volume: f64,
-    },
-    /// Play some music.
-    ///
-    /// Any current music is stopped.
-    PlayMusic {
-        /// The handle for the music.
-        sound_source: Handle<AudioSource>,
-        /// The settings for the music.
-        sound_settings: Box<StaticSoundSettings>,
-    },
-    /// Play a sound.
-    PlaySound {
-        /// The handle to the sound to play.
-        sound_source: Handle<AudioSource>,
-        /// The volume to play the sound at.
-        volume: f64,
-    },
-}
-
-#[derive(HasSchema)]
-#[schema(no_clone, no_default, opaque)]
-#[repr(C)]
-pub struct Audio {
-    /// The handle for the audio.
-    handle: StaticSoundHandle,
-    /// The original volume requested for the audio.
-    volume: f64,
-}
-
-fn process_audio_events(
-    mut audio_manager: ResMut<AudioManager>,
-    mut audio_center: ResMut<AudioCenter>,
-    assets: ResInit<AssetServer>,
-    mut entities: ResMut<Entities>,
-    mut audios: CompMut<Audio>,
-    storage: Res<Storage>,
-) {
-    let settings = storage.get::<Settings>().unwrap();
-
-    for event in audio_center.events.drain(..).collect::<Vec<_>>() {
-        match event {
-            AudioEvent::VolumeChange {
-                main_volume,
-                music_volume,
-                effects_volume,
-            } => {
-                let tween = Tween::default();
-                // Update music volume
-                if let Some(music) = &mut audio_center.music {
-                    let volume = main_volume * music_volume * music.volume;
-                    if let Err(err) = music.handle.set_volume(volume, tween) {
-                        warn!("Error setting music volume: {err}");
-                    }
-                }
-                // Update sound volumes
-                for audio in audios.iter_mut() {
-                    let volume = main_volume * effects_volume * audio.volume;
-                    if let Err(err) = audio.handle.set_volume(volume, tween) {
-                        warn!("Error setting audio volume: {err}");
-                    }
-                }
-            }
-            AudioEvent::PlayMusic {
-                sound_source,
-                mut sound_settings,
-            } => {
-                // Stop the current music
-                if let Some(mut music) = audio_center.music.take() {
-                    let tween = Tween {
-                        start_time: kira::StartTime::Immediate,
-                        duration: MUSIC_FADE_DURATION,
-                        easing: tween::Easing::Linear,
-                    };
-                    music.handle.stop(tween).unwrap();
-                }
-                // Scale the requested volume by the settings value
-                let volume = match sound_settings.volume {
-                    tween::Value::Fixed(vol) => vol.as_amplitude(),
-                    _ => MUSIC_VOLUME,
-                };
-                let scaled_volume = settings.main_volume * settings.music_volume * volume;
-                sound_settings.volume = tween::Value::Fixed(Volume::Amplitude(scaled_volume));
-                // Play the new music
-                let sound_data = assets.get(sound_source).with_settings(*sound_settings);
-                match audio_manager.play(sound_data) {
-                    Err(err) => warn!("Error playing music: {err}"),
-                    Ok(handle) => audio_center.music = Some(Audio { handle, volume }),
-                }
-            }
-            AudioEvent::PlaySound {
-                sound_source,
-                volume,
-            } => {
-                let scaled_volume = settings.main_volume * settings.effects_volume * volume;
-                let sound_data = assets
-                    .get(sound_source)
-                    .with_settings(StaticSoundSettings::default().volume(scaled_volume));
-                match audio_manager.play(sound_data) {
-                    Err(err) => warn!("Error playing sound: {err}"),
-                    Ok(handle) => {
-                        let audio_ent = entities.create();
-                        audios.insert(audio_ent, Audio { handle, volume });
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn kill_finished_audios(entities: Res<Entities>, audios: Comp<Audio>, mut commands: Commands) {
-    for (audio_ent, audio) in entities.iter_with(&audios) {
-        if audio.handle.state() == PlaybackState::Stopped {
-            commands.add(move |mut entities: ResMut<Entities>| entities.kill(audio_ent));
-        }
     }
 }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -7,9 +7,9 @@ pub use music::*;
 pub fn game_plugin(game: &mut Game) {
     game.init_shared_resource::<AudioCenter>();
 
-    let session = match game.sessions.get_mut(DEFAULT_BONES_AUDIO_SESSION) {
+    let session = match game.sessions.get_mut(SessionNames::AUDIO) {
         Some(session) => session,
-        None => panic!("Audio plugin failed to find `DEFAULT_BONES_AUDIO_SESSION`, make sure jumpy audio plugin is installed after bones default plugins.")
+        None => panic!("Audio plugin failed to find existing bones audio session, make sure jumpy audio plugin is installed after bones default plugins.")
     };
 
     session.stages.add_system_to_stage(First, music_system);

--- a/src/audio/music.rs
+++ b/src/audio/music.rs
@@ -64,10 +64,10 @@ pub(super) fn music_system(
         if let MusicState::Fight { idx } = &mut *music_state {
             if let Some(PlaybackState::Stopped) = audio.music_state() {
                 *idx = (*idx + 1) % shuffled_fight_music.len();
-                audio.play_music(shuffled_fight_music[*idx], play_settings);
+                audio.play_music_from_settings(shuffled_fight_music[*idx], play_settings, true);
             }
         } else if let Some(song) = shuffled_fight_music.get(0) {
-            audio.play_music(*song, play_settings);
+            audio.play_music_from_settings(*song, play_settings, false);
             *music_state = MusicState::Fight { idx: 0 };
         }
 
@@ -77,22 +77,23 @@ pub(super) fn music_system(
         match menu_page {
             MenuPage::PlayerSelect | MenuPage::MapSelect { .. } | MenuPage::NetworkGame => {
                 if *music_state != MusicState::CharacterSelect {
-                    audio.play_music(
+                    audio.play_music_from_settings(
                         meta.music.title_screen,
                         play_settings.loop_region(Region::default()),
+                        false,
                     );
                     *music_state = MusicState::CharacterSelect;
                 }
             }
             MenuPage::Home | MenuPage::Settings => {
                 if *music_state != MusicState::MainMenu {
-                    audio.play_music(meta.music.title_screen, play_settings);
+                    audio.play_music_from_settings(meta.music.title_screen, play_settings, false);
                     *music_state = MusicState::MainMenu;
                 }
             }
             MenuPage::Credits => {
                 if *music_state != MusicState::Credits {
-                    audio.play_music(meta.music.credits, play_settings);
+                    audio.play_music_from_settings(meta.music.credits, play_settings, false);
                     *music_state = MusicState::Credits;
                 }
             }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -2,7 +2,7 @@ use crate::{core::JumpyDefaultMatchRunner, prelude::*, ui::scoring::ScoringMenuS
 
 pub struct SessionNames;
 impl SessionNames {
-    pub const AUDIO: &'static str = "audio";
+    pub const AUDIO: &'static str = DEFAULT_BONES_AUDIO_SESSION;
     pub const DEBUG: &'static str = "debug";
     pub const GAME: &'static str = "game";
     pub const MAIN_MENU: &'static str = "main_menu";

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -26,11 +26,11 @@ fn load_settings(game: &mut Game) {
 pub struct Settings {
     /// The main scaling factor for all game audios. This is done on top of the
     /// scaling factor specific to the audio type.
-    pub main_volume: f64,
+    pub main_volume: f32,
     /// The scaling factor for music.
-    pub music_volume: f64,
+    pub music_volume: f32,
     /// The scaling factor for sound effects.
-    pub effects_volume: f64,
+    pub effects_volume: f32,
     /// Whether to display the game fullscreen.
     pub fullscreen: bool,
     /// The player controller bindings

--- a/src/ui/main_menu/settings/audio.rs
+++ b/src/ui/main_menu/settings/audio.rs
@@ -8,16 +8,16 @@ trait SettingsExts {
 
 impl SettingsExts for Settings {
     fn volume_change_event(&self) -> AudioEvent {
-        AudioEvent::VolumeChange {
-            main_volume: self.main_volume,
-            music_volume: self.music_volume,
-            effects_volume: self.effects_volume,
+        AudioEvent::VolumeScaleUpdate {
+            main_volume_scale: self.main_volume,
+            music_volume_scale: self.music_volume,
+            effects_volume_scale: self.effects_volume,
         }
     }
 }
 
 pub(super) fn on_cancel(In(state): In<&SettingsState>, mut audio_center: ResMut<AudioCenter>) {
-    audio_center.event(state.modified_settings.volume_change_event());
+    audio_center.push_event(state.modified_settings.volume_change_event());
 }
 
 pub(super) fn widget(
@@ -39,7 +39,7 @@ pub(super) fn widget(
 
     if should_reset {
         state.modified_settings.main_volume = meta.default_settings.main_volume;
-        audio_center.event(state.modified_settings.volume_change_event());
+        audio_center.push_event(state.modified_settings.volume_change_event());
     }
 
     ui.add_space(normal_font.size);
@@ -85,7 +85,7 @@ pub(super) fn widget(
                 ui.end_row();
 
                 if main_changed || music_changed || effects_changed {
-                    audio_center.event(state.modified_settings.volume_change_event());
+                    audio_center.push_event(state.modified_settings.volume_change_event());
                 }
             });
         });
@@ -95,7 +95,7 @@ pub(super) fn widget(
 fn volume_control_widget(
     ui: &mut egui::Ui,
     label: impl Into<egui::WidgetText>,
-    value: &mut f64,
+    value: &mut f32,
 ) -> egui::Response {
     ui.label(label);
     let slider = egui::Slider::new(value, 0.0..=1.0)


### PR DESCRIPTION
Use AudioCenter from bones now that it has been moved there, and remove from Jumpy.

Added a trait extension to continue playing music from kira `StaticSoundSettings`, to avoid having to put all of the params in `play_music_advanced`, as the looping is configured a bit differently.

The addition of `force_restart` in PlayMusic event has been helpful, now music does not restart each time switch menu pages.

Resolves #1016 