### PR TITLE
fix(settings): networking tab input

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -74,10 +74,6 @@ pub fn handle_egui_input(game: &mut Game, egui_input: &mut egui::RawInput) {
 
     // Forward gamepad events to egui if not disabled.
     if !settings.disable_gamepad_input {
-        let mapping = &game
-            .shared_resource::<PlayerControlMapping>()
-            .unwrap()
-            .gamepad;
         let input_collector = game.shared_resource::<PlayerInputCollector>().unwrap();
         let gamepad = game.shared_resource::<GamepadInputs>().unwrap();
 
@@ -129,33 +125,39 @@ pub fn handle_egui_input(game: &mut Game, egui_input: &mut egui::RawInput) {
                 _ => false,
             };
 
-            // TODO: remove `clone()` when this type implements `Copy`
-            if mapping_is_active(mapping.menu_confirm.clone()) {
-                push_key(events, egui::Key::Enter);
-            }
-            // TODO: remove `clone()` when this type implements `Copy`
-            if mapping_is_active(mapping.menu_back.clone()) {
-                push_key(events, egui::Key::Escape);
-            }
-
-            // helper for merging two inputs (like dpad + joystick for example) allowing multiple bindings
-            // for same control
-            let merge_inputs = |input1: &InputKind, input2: &InputKind| {
+            if let Some(mapping) = &game
+                .shared_resource::<PlayerControlMapping>()
+                .as_ref()
+                .map(|m| &m.gamepad)
+            {
                 // TODO: remove `clone()` when this type implements `Copy`
-                mapping_is_active(input1.clone()) || mapping_is_active(input2.clone())
-            };
+                if mapping_is_active(mapping.menu_confirm.clone()) {
+                    push_key(events, egui::Key::Enter);
+                }
+                // TODO: remove `clone()` when this type implements `Copy`
+                if mapping_is_active(mapping.menu_back.clone()) {
+                    push_key(events, egui::Key::Escape);
+                }
 
-            if merge_inputs(&mapping.movement.left, &mapping.movement_alt.left) {
-                push_key(events, egui::Key::ArrowLeft);
-            }
-            if merge_inputs(&mapping.movement.right, &mapping.movement_alt.right) {
-                push_key(events, egui::Key::ArrowRight);
-            }
-            if merge_inputs(&mapping.movement.up, &mapping.movement_alt.up) {
-                push_key(events, egui::Key::ArrowUp);
-            }
-            if merge_inputs(&mapping.movement.down, &mapping.movement_alt.down) {
-                push_key(events, egui::Key::ArrowDown);
+                // helper for merging two inputs (like dpad + joystick for example) allowing multiple bindings
+                // for same control
+                let merge_inputs = |input1: &InputKind, input2: &InputKind| {
+                    // TODO: remove `clone()` when this type implements `Copy`
+                    mapping_is_active(input1.clone()) || mapping_is_active(input2.clone())
+                };
+
+                if merge_inputs(&mapping.movement.left, &mapping.movement_alt.left) {
+                    push_key(events, egui::Key::ArrowLeft);
+                }
+                if merge_inputs(&mapping.movement.right, &mapping.movement_alt.right) {
+                    push_key(events, egui::Key::ArrowRight);
+                }
+                if merge_inputs(&mapping.movement.up, &mapping.movement_alt.up) {
+                    push_key(events, egui::Key::ArrowUp);
+                }
+                if merge_inputs(&mapping.movement.down, &mapping.movement_alt.down) {
+                    push_key(events, egui::Key::ArrowDown);
+                }
             }
         }
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -426,10 +426,18 @@ impl<'a>
             // helper for merging two inputs (like dpad + joystick for example) allowing multiple bindings
             // for same control
             let merge_inputs = |input1: &InputKind, input2: &InputKind| -> Option<f32> {
-                get_input_value(input1, source)
-                    .filter(|v| *v != 0.0)
-                    .or_else(|| get_input_value(input2, source))
-                    .map(f32::abs)
+                match (
+                    get_input_value(input1, source),
+                    get_input_value(input2, source),
+                ) {
+                    // Both inputs have a value and the first is zero -- use the second value
+                    (Some(0.0), Some(value2)) => Some(value2),
+                    // First input has a non-zero value -- use the first value
+                    (Some(value1), _) => Some(value1),
+                    // First input has no value -- use the second
+                    (None, value2) => value2,
+                }
+                .map(f32::abs)
             };
 
             if let Some(left) = merge_inputs(&mapping.movement.left, &mapping.movement_alt.left) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -93,7 +93,7 @@ pub fn handle_egui_input(game: &mut Game, egui_input: &mut egui::RawInput) {
 
             let mapping_is_active = |input_map: InputKind| match input_map {
                 InputKind::Button(mapped_button) => {
-                    for input in &gamepad.gamepad_events {
+                    for input in gamepad.gamepad_events.iter().rev() {
                         if let GamepadEvent::Button(e) = input {
                             if e.button == mapped_button && e.gamepad == gamepad_idx {
                                 return e.value >= 0.1;
@@ -103,7 +103,7 @@ pub fn handle_egui_input(game: &mut Game, egui_input: &mut egui::RawInput) {
                     false
                 }
                 InputKind::AxisPositive(mapped_axis) => {
-                    for input in &gamepad.gamepad_events {
+                    for input in gamepad.gamepad_events.iter().rev() {
                         if let GamepadEvent::Axis(e) = input {
                             if e.axis == mapped_axis && e.gamepad == gamepad_idx {
                                 return e.value >= 0.1;
@@ -113,7 +113,7 @@ pub fn handle_egui_input(game: &mut Game, egui_input: &mut egui::RawInput) {
                     false
                 }
                 InputKind::AxisNegative(mapped_axis) => {
-                    for input in &gamepad.gamepad_events {
+                    for input in gamepad.gamepad_events.iter().rev() {
                         if let GamepadEvent::Axis(e) = input {
                             if e.axis == mapped_axis && e.gamepad == gamepad_idx {
                                 return e.value <= -0.1;
@@ -350,7 +350,7 @@ impl<'a>
             control_source,
         ) {
             (InputKind::Button(mapped_button), ControlSource::Gamepad(idx)) => {
-                for input in &gamepad.gamepad_events {
+                for input in gamepad.gamepad_events.iter().rev() {
                     if let GamepadEvent::Button(e) = input {
                         if &e.button == mapped_button && e.gamepad == *idx {
                             let value = if e.value < 0.1 { 0.0 } else { e.value };
@@ -361,7 +361,7 @@ impl<'a>
                 None
             }
             (InputKind::AxisPositive(mapped_axis), ControlSource::Gamepad(idx)) => {
-                for input in &gamepad.gamepad_events {
+                for input in gamepad.gamepad_events.iter().rev() {
                     if let GamepadEvent::Axis(e) = input {
                         if &e.axis == mapped_axis && e.gamepad == *idx {
                             let value = if e.value < 0.1 { 0.0 } else { e.value };
@@ -372,7 +372,7 @@ impl<'a>
                 None
             }
             (InputKind::AxisNegative(mapped_axis), ControlSource::Gamepad(idx)) => {
-                for input in &gamepad.gamepad_events {
+                for input in gamepad.gamepad_events.iter().rev() {
                     if let GamepadEvent::Axis(e) = input {
                         if &e.axis == mapped_axis && e.gamepad == *idx {
                             let value = if e.value > -0.1 { 0.0 } else { e.value };
@@ -386,7 +386,7 @@ impl<'a>
                 InputKind::Keyboard(mapped_key),
                 ControlSource::Keyboard1 | ControlSource::Keyboard2,
             ) => {
-                for input in &keyboard.key_events {
+                for input in keyboard.key_events.iter().rev() {
                     if input.key_code.option() == Some(*mapped_key) {
                         return Some(if input.button_state.pressed() {
                             1.0

--- a/src/ui/main_menu/settings/networking.rs
+++ b/src/ui/main_menu/settings/networking.rs
@@ -7,11 +7,6 @@ pub(super) fn widget(
 ) {
     let (ui, state, should_reset) = &mut *args;
 
-    ui.ctx().set_state(EguiInputSettings {
-        disable_gamepad_input: true,
-        disable_keyboard_input: false,
-    });
-
     let bigger_font = meta
         .theme
         .font_styles

--- a/src/ui/main_menu/settings/networking.rs
+++ b/src/ui/main_menu/settings/networking.rs
@@ -7,6 +7,11 @@ pub(super) fn widget(
 ) {
     let (ui, state, should_reset) = &mut *args;
 
+    ui.ctx().set_state(EguiInputSettings {
+        disable_gamepad_input: true,
+        disable_keyboard_input: false,
+    });
+
     let bigger_font = meta
         .theme
         .font_styles


### PR DESCRIPTION
Fixes #933 

Disabling only gamepad input seems to make the input behave as one would expect. Arrow keys, backspace, etc work like normal, and bound keys (e.g. A, D) only update the text and no longer move the caret.

Unfortunately I don't have a controller to test with, but I assume this will work with those kind of inputs too.