### PR TITLE
chore: bump actions/upload-artifacts  to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
           tar -czvf $artifact_path $release_dir/
 
       - name: ⏫️ Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_PATH }}
           path: ${{ env.ARTIFACT_PATH }}


### PR DESCRIPTION
We updated download-artifacts to v4 but not upload, seems to have broken release pipeline, hopefully this fixes.