### PR TITLE
fix(player_select): Fix Online game able to start without all playes ready 

### DIFF
--- a/src/ui/main_menu/player_select.rs
+++ b/src/ui/main_menu/player_select.rs
@@ -273,8 +273,7 @@ pub fn widget(
     localization: Localization<GameMeta>,
     controls: Res<GlobalPlayerControls>,
     world: &World,
-
-    #[cfg(not(target_arch = "wasm32"))] asset_server: Res<AssetServer>,
+    asset_server: Res<AssetServer>,
     #[cfg(not(target_arch = "wasm32"))] network_socket: Option<Res<NetworkMatchSocket>>,
 ) {
     let mut state = ui.ctx().get_state::<PlayerSelectState>();

--- a/src/ui/main_menu/player_select.rs
+++ b/src/ui/main_menu/player_select.rs
@@ -98,7 +98,7 @@ impl PlayerSlot {
         matches!(self, Self::Ready { .. })
     }
 
-    pub fn is_user(&self) -> bool {
+    pub fn is_local_player(&self) -> bool {
         match self {
             Self::Empty => false,
             Self::SelectingLocalControlSource => true,
@@ -895,7 +895,7 @@ fn player_select_panel(
                 };
                 ui.vertical_centered(|ui| {
                     if !slot.is_ready() {
-                        if slot.is_user() {
+                        if slot.is_local_player() {
                             if slot.is_selecting_hat() {
                                 ui.label(normal_font.rich(localization.get("pick-a-hat")));
                             } else {
@@ -937,7 +937,7 @@ fn player_select_panel(
                     ui.vertical_centered(|ui| {
                         ui.set_height(heading_font.size * 1.5);
 
-                        if slot.is_ready() && !slot.is_ai() && slot.is_user() {
+                        if slot.is_ready() && !slot.is_ai() && slot.is_local_player() {
                             ui.label(
                                 heading_font
                                     .with_color(meta.theme.colors.positive)

--- a/src/ui/main_menu/player_select.rs
+++ b/src/ui/main_menu/player_select.rs
@@ -928,26 +928,27 @@ fn player_select_panel(
                                 },
                             )));
                         }
-                    } else {
-                        ui.label(normal_font.rich(localization.get("waiting")));
                     }
 
                     ui.vertical_centered(|ui| {
                         ui.set_height(heading_font.size * 1.5);
 
-                        if slot.is_ready() && !slot.is_ai() && slot.is_local_player() {
+                        if slot.is_ready() && !slot.is_ai() {
                             ui.label(
                                 heading_font
                                     .with_color(meta.theme.colors.positive)
                                     .rich(localization.get("player-select-ready")),
                             );
                             ui.add_space(normal_font.size / 2.0);
-                            ui.label(normal_font.rich(localization.get_with(
-                                "player-select-unready",
-                                &fluent_args! {
-                                    "button" => back_binding.as_str()
-                                },
-                            )));
+
+                            if slot.is_local_player() {
+                                ui.label(normal_font.rich(localization.get_with(
+                                    "player-select-unready",
+                                    &fluent_args! {
+                                        "button" => back_binding.as_str()
+                                    },
+                                )));
+                            }
                         }
                         if !is_network && slot_id != 0 && slot.is_ai() {
                             ui.label(

--- a/src/ui/main_menu/player_select.rs
+++ b/src/ui/main_menu/player_select.rs
@@ -341,7 +341,7 @@ pub fn widget(
     // transition to map select. Transition slots of required players from empty to initial state.
     //
     // In Offline, we have one required player. Other slots are optional.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     {
         let first_slot = &mut state.slots[0];
         if first_slot.is_empty() {
@@ -360,7 +360,7 @@ pub fn widget(
                 // unused slots in online don't need to be initialized
                 break;
             } else if is_local_player_slot && is_empty {
-                *slot = PlayerSlot::SelectingLocalControlSource
+                *slot = PlayerSlot::SelectingLocalControlSource;
             } else if !is_local_player_slot && is_empty {
                 *slot = PlayerSlot::SelectingPlayer {
                     control_source: PlayerSlotControlSource::Remote,

--- a/src/ui/main_menu/player_select.rs
+++ b/src/ui/main_menu/player_select.rs
@@ -622,8 +622,6 @@ fn player_select_panel(
         None => (None, is_next_open_slot),
     };
 
-    let slot_is_network_local_player = Some(slot_id) == network_local_player_slot;
-
     //
     // React to user inputs
     //
@@ -829,8 +827,10 @@ fn player_select_panel(
             let smaller_font = &meta.theme.font_styles.smaller.with_color(panel.font_color);
             let heading_font = &meta.theme.font_styles.heading.with_color(panel.font_color);
 
+            let slot = state.slots[slot_id as usize];
+
             // Marker for current player in online matches
-            if slot_is_network_local_player {
+            if is_network && slot.is_local_player() {
                 ui.vertical_centered(|ui| {
                     ui.label(normal_font.rich(localization.get("you-marker")));
                 });
@@ -839,8 +839,6 @@ fn player_select_panel(
             }
 
             ui.add_space(normal_font.size);
-
-            let slot = state.slots[slot_id as usize];
 
             let display_fish =
                 |ui: &mut egui::Ui,
@@ -982,7 +980,7 @@ fn player_select_panel(
                     .join("/");
 
                 ui.vertical_centered(|ui| {
-                    if !is_network || slot_is_network_local_player {
+                    if !is_network || slot.is_local_player() {
                         ui.label(normal_font.rich(localization.get_with(
                             "press-button-to-join",
                             &fluent_args! {


### PR DESCRIPTION
Fixes #1036 and couple other things along the way

Not entirely sure what caused this - but I think I introduced it when updating for new matchmaker interface in bones.

We would allow online matches to continue if >1 players are ready and no unconfirmed players. The issue is that in online remote players who had not made a selection were in `Empty` state, and not tracked as unconfirmed. Now for any local + required players, I initialize them to new PlayerSlot type `SelectingLocalControlSource`. `Empty` may be used for online slots that are unused (the last 2 slots in a 2 player game) in online, or for lan, optional slots that may be joined by additional players/AI, but are not required. And remote required players are set to `SelectingPlayer` with default fish + no hat - as next message expected from them is change in player, and they don't need to select control source, we know they are remote.

This seems to have fixed the match starting without all players ready, as all required players are initialized to something other than `Empty`.


### Other fixes / changes

#### Remembering Hats:

I noticed that if you select a hat and then deselect it going back to fish select - the other online players would still see this hat, but local player resets to None. If player selected hat, went back to fish select, then readied up with no hat, the remote players would see hat, but not the local player. This could cause desync. Now When you go back to fish select, your hat is remembered. 

#### Always display default fish:
We were no longer displaying default fish in online when player had not yet selected a control source/fish. Now regardless of if have actually selected a fish, the default fish + no hat is shown (If the slot is a required player that we are sure will select one eventually / must ready up). In local for unjoined slots, no default fish is shown until joined or AI is set.

#### Show when remote players ready
In online when a remote player is ready, this is now displayed.

@nelson137 feel free to review (if you want) as I know you were just in here. Player select sure is complicated lol, but feeling good about the changes I think we're making it more manageable 😅